### PR TITLE
Fix out params in VisitCRUDManager

### DIFF
--- a/FilmCRUD/VisitCRUDManager.cs
+++ b/FilmCRUD/VisitCRUDManager.cs
@@ -137,13 +137,13 @@ namespace FilmCRUD
             IEnumerable<string> newRipFileNamesWithoutManualInfo = _newRipFileNames.Except(newRipFileNamesWithManualInfo).ToList();
 
 
-            List<string> manualParsingErrors = new();
+            List<string> manualParsingErrors;
             IEnumerable<MovieRip> newMovieRipsManual = GetManualMovieRipsFromDictionaries(
                 manualMovieRips.Where(kvp => newRipFileNamesWithManualInfo.Contains(kvp.Key)),
                 out manualParsingErrors
                 );
 
-            List<string> parsingErrors = new();
+            List<string> parsingErrors;
             IEnumerable<MovieRip> newMovieRips = ConvertFileNamesToMovieRips(newRipFileNamesWithoutManualInfo, out parsingErrors);
 
             List<string> allParsingErrors = manualParsingErrors.Concat(parsingErrors).ToList();


### PR DESCRIPTION
No need to initialize before calling these methods: GetManualMovieRipsFromDictionaries, ConvertFileNamesToMovieRips.