### PR TITLE
Add new method GetAllAsNoTracking to IEntityRepository and use in scan verb classes

### DIFF
--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -17,7 +17,6 @@ using ConfigUtils.Interfaces;
 using MovieAPIClients.Interfaces;
 using MovieAPIClients.TheMovieDb;
 
-
 namespace FilmCRUD
 {
     class Program


### PR DESCRIPTION
ScanRipsManager and ScanMoviesManager do not change any entities so they do not need tracking of entities.

- add GetAllAsNoTracking method to IEntityRepository
- implement in GenericRepository (FilmDataAccess.EFCore.Repositories)
- use in ScanRipsManager and ScanMoviesManager 