### PR TITLE
Amend GetCount mehods in ScanMoviesManager: should aggregate using only the provided visit

### DIFF
--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -203,19 +203,19 @@ namespace DepotTests.CRUDTests
         public void GetCountByDirector_ShouldReturnCorrectCount()
         {
             // arrange
-            var firstMovie = new Movie() { Title = "uncut gems", ReleaseDate = 2019 };
-            var secondMovie = new Movie() { Title = "there will be blood", ReleaseDate = 2007 };
-            var thirdMovie = new Movie() { Title = "Licorice Pizza", ReleaseDate = 2021 };
+            var firstDirector = new Director() { Name = "benny safdie" };
+            var secondDirector = new Director() { Name = "josh safdie" };
+            var thirdDirector = new Director() { Name = "paul thomas anderson" };
 
-            var firstDirector = new Director() { Name = "benny safdie", Movies = new List<Movie>() { firstMovie } };
-            var secondDirector = new Director() { Name = "josh safdie", Movies = new List<Movie>() { firstMovie } };
-            var thirdDirector = new Director() { Name = "paul thomas anderson", Movies = new List<Movie>() { secondMovie, thirdMovie } };
+            var firstMovie = new Movie() { Title = "uncut gems", ReleaseDate = 2019, Directors = new Director[] { firstDirector, secondDirector } };
+            var secondMovie = new Movie() { Title = "there will be blood", ReleaseDate = 2007, Directors = new Director[] { thirdDirector } };
+            var thirdMovie = new Movie() { Title = "Licorice Pizza", ReleaseDate = 2021, Directors = new Director[] { thirdDirector } };
 
             var visit = new MovieWarehouseVisit() { VisitDateTime = DateTime.ParseExact("20220101", "yyyyMMdd", null) };
 
-            this._directorRepositoryMock
-                .Setup(d => d.GetAll())
-                .Returns(new Director[] { firstDirector, secondDirector, thirdDirector });
+            this._movieRepositoryMock
+                .Setup(m => m.GetAllMoviesInVisit(visit))
+                .Returns(new Movie[] { firstMovie, secondMovie, thirdMovie });
 
             // act
             IEnumerable<KeyValuePair<Director, int>> actual = this._scanMoviesManager.GetCountByDirector(visit);

--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -173,19 +173,19 @@ namespace DepotTests.CRUDTests
         public void GetCountByActor_ShouldReturnCorrectCount()
         {
             // arrange
-            var firstMovie = new Movie() { Title = "the fly", ReleaseDate = 1986 };
-            var secondMovie = new Movie() { Title = "independence day", ReleaseDate = 1996 };
-            var thirdMovie = new Movie() { Title = "dumb and dumber", ReleaseDate = 1994 };
+            var firstActor = new Actor() { Name = "jeff goldblum" };
+            var secondActor = new Actor() { Name = "bill pullman" };
+            var thirdActor = new Actor() { Name = "jim carrey" };
 
-            var firstActor = new Actor() { Name = "jeff goldblum", Movies = new List<Movie>() { firstMovie, secondMovie } };
-            var secondActor = new Actor() { Name = "bill pullman", Movies = new List<Movie>() { firstMovie } };
-            var thirdActor = new Actor() { Name = "jim carrey", Movies =  new List<Movie>() { thirdMovie } };
+            var firstMovie = new Movie() { Title = "the fly", ReleaseDate = 1986, Actors = new Actor[] { firstActor, secondActor } };
+            var secondMovie = new Movie() { Title = "independence day", ReleaseDate = 1996, Actors = new Actor[] { firstActor } };
+            var thirdMovie = new Movie() { Title = "dumb and dumber", ReleaseDate = 1994, Actors = new Actor[] { thirdActor } };
 
             var visit = new MovieWarehouseVisit() { VisitDateTime = DateTime.ParseExact("20220101", "yyyyMMdd", null) };
 
-            this._actoRepositoryMock
-                .Setup(a => a.GetAll())
-                .Returns(new Actor[] { firstActor, secondActor, thirdActor });
+            this._movieRepositoryMock
+                .Setup(m => m.GetAllMoviesInVisit(visit))
+                .Returns(new Movie[] { firstMovie, secondMovie, thirdMovie });
 
             // act
             IEnumerable<KeyValuePair<Actor, int>> actual = this._scanMoviesManager.GetCountByActor(visit);

--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -143,19 +143,19 @@ namespace DepotTests.CRUDTests
         public void GetCountByGenre_ShouldReturnCorrectCount()
         {
             // arrange
-            var firstMovie = new Movie() { Title = "the fly", ReleaseDate = 1986 };
-            var secondMovie = new Movie() {Title = "gummo", ReleaseDate = 1997 };
-            var thirdMovie = new Movie() { Title = "dumb and dumber", ReleaseDate = 1994 };
+            var dramaGenre = new Genre() { Name = "drama" };
+            var horrorGenre = new Genre() { Name = "horror" };
+            var comedyGenre = new Genre() { Name = "comedy" };
 
-            var dramaGenre = new Genre() { Name = "drama", Movies = new List<Movie>() { firstMovie, secondMovie }};
-            var horrorGenre = new Genre() { Name = "horror", Movies = new List<Movie>() { firstMovie } };
-            var comedyGenre = new Genre() { Name = "comedy", Movies = new List<Movie>() { thirdMovie } };
+            var firstMovie = new Movie() { Title = "the fly", ReleaseDate = 1986, Genres = new Genre[] { dramaGenre, horrorGenre } };
+            var secondMovie = new Movie() {Title = "gummo", ReleaseDate = 1997, Genres = new Genre[] { dramaGenre } };
+            var thirdMovie = new Movie() { Title = "dumb and dumber", ReleaseDate = 1994, Genres = new Genre[] { comedyGenre } };
 
             var visit = new MovieWarehouseVisit() { VisitDateTime = DateTime.ParseExact("20220101", "yyyyMMdd", null) };
 
-            this._genreRepositoryMock
-                .Setup(g => g.GetAll())
-                .Returns(new Genre[] { dramaGenre, horrorGenre, comedyGenre });
+            this._movieRepositoryMock
+                .Setup(m => m.GetAllMoviesInVisit(visit))
+                .Returns(new Movie[] { firstMovie, secondMovie, thirdMovie });
 
             // act
             IEnumerable<KeyValuePair<Genre, int>> actual = this._scanMoviesManager.GetCountByGenre(visit);

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -206,7 +206,7 @@ namespace FilmCRUD
                 System.Console.WriteLine("Count by genre:\n");
                 IEnumerable<KeyValuePair<Genre, int>> genreCount = scanMoviesManager.GetCountByGenre(visit);
                 int toTake = opts.Top ?? genreCount.Count();
-                genreCount.OrderByDescending(kvp => kvp.Value)
+                genreCount.OrderByDescending(kvp => kvp.Value).ThenBy(kvp => kvp.Key.Name)
                     .Take(toTake)
                     .ToList()
                     .ForEach(kvp => System.Console.WriteLine($"{kvp.Key.Name}: {kvp.Value}"));
@@ -216,7 +216,7 @@ namespace FilmCRUD
                 System.Console.WriteLine("Count by actor:\n");
                 IEnumerable<KeyValuePair<Actor, int>> actorCount = scanMoviesManager.GetCountByActor(visit);
                 int toTake = opts.Top ?? actorCount.Count();
-                actorCount.OrderByDescending(kvp => kvp.Value)
+                actorCount.OrderByDescending(kvp => kvp.Value).ThenBy(kvp => kvp.Key.Name)
                     .Take(toTake)
                     .ToList()
                     .ForEach(kvp => System.Console.WriteLine($"{kvp.Key.Name}: {kvp.Value}"));
@@ -226,7 +226,7 @@ namespace FilmCRUD
                 System.Console.WriteLine("Count by director:\n");
                 IEnumerable<KeyValuePair<Director, int>> directorCount = scanMoviesManager.GetCountByDirector(visit);
                 int toTake = opts.Top ?? directorCount.Count();
-                directorCount.OrderByDescending(kvp => kvp.Value)
+                directorCount.OrderByDescending(kvp => kvp.Value).ThenBy(kvp => kvp.Key.Name)
                     .Take(toTake)
                     .ToList()
                     .ForEach(kvp => System.Console.WriteLine($"{kvp.Key.Name}: {kvp.Value}"));

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -49,7 +49,6 @@ namespace FilmCRUD
             parsed.WithNotParsed(HandleParseError);
 
             {}
-
         }
 
         private static void ConfigureServices(IServiceCollection services)

--- a/FilmCRUD/ScanMoviesManager.cs
+++ b/FilmCRUD/ScanMoviesManager.cs
@@ -56,9 +56,9 @@ namespace FilmCRUD
         {
             IEnumerable<Movie> moviesInVisit = this._unitOfWork.Movies.GetAllMoviesInVisit(visit);
 
-            // flatten -> distinct
-            IEnumerable<Actor> actorsInVisit = moviesInVisit.SelectMany(m => m.Actors).Distinct().ToList();
-            return actorsInVisit.Select(a => new KeyValuePair<Actor, int>(a, a.Movies.Count()));
+            // flatten -> group by Actor and count
+            IEnumerable<IGrouping<Actor, Actor>> grouped = moviesInVisit.SelectMany(m => m.Actors).GroupBy(a => a);
+            return grouped.Select(group => new KeyValuePair<Actor, int>(group.Key, group.Count()));
         }
 
         public IEnumerable<KeyValuePair<Director, int>> GetCountByDirector(MovieWarehouseVisit visit)

--- a/FilmCRUD/ScanMoviesManager.cs
+++ b/FilmCRUD/ScanMoviesManager.cs
@@ -49,7 +49,11 @@ namespace FilmCRUD
 
         public IEnumerable<KeyValuePair<Genre, int>> GetCountByGenre(MovieWarehouseVisit visit)
         {
-            return this._unitOfWork.Genres.GetAll().Select(g => new KeyValuePair<Genre, int>(g, g.Movies.Count()));
+            IEnumerable<Movie> moviesInVisit = this._unitOfWork.Movies.GetAllMoviesInVisit(visit);
+
+            // flatten -> group by Genre and count
+            IEnumerable<IGrouping<Genre, Genre>> grouped = moviesInVisit.SelectMany(m => m.Genres).GroupBy(g => g);
+            return grouped.Select(group => new KeyValuePair<Genre, int>(group.Key, group.Count()));
         }
 
         public IEnumerable<KeyValuePair<Actor, int>> GetCountByActor(MovieWarehouseVisit visit)

--- a/FilmCRUD/ScanMoviesManager.cs
+++ b/FilmCRUD/ScanMoviesManager.cs
@@ -54,7 +54,11 @@ namespace FilmCRUD
 
         public IEnumerable<KeyValuePair<Actor, int>> GetCountByActor(MovieWarehouseVisit visit)
         {
-            return this._unitOfWork.Actors.GetAll().Select(a => new KeyValuePair<Actor, int>(a, a.Movies.Count()));
+            IEnumerable<Movie> moviesInVisit = this._unitOfWork.Movies.GetAllMoviesInVisit(visit);
+
+            // flatten -> distinct
+            IEnumerable<Actor> actorsInVisit = moviesInVisit.SelectMany(m => m.Actors).Distinct().ToList();
+            return actorsInVisit.Select(a => new KeyValuePair<Actor, int>(a, a.Movies.Count()));
         }
 
         public IEnumerable<KeyValuePair<Director, int>> GetCountByDirector(MovieWarehouseVisit visit)

--- a/FilmCRUD/ScanMoviesManager.cs
+++ b/FilmCRUD/ScanMoviesManager.cs
@@ -67,7 +67,11 @@ namespace FilmCRUD
 
         public IEnumerable<KeyValuePair<Director, int>> GetCountByDirector(MovieWarehouseVisit visit)
         {
-            return this._unitOfWork.Directors.GetAll().Select(d => new KeyValuePair<Director, int>(d, d.Movies.Count()));
+            IEnumerable<Movie> moviesInVisit = this._unitOfWork.Movies.GetAllMoviesInVisit(visit);
+
+            // flatten -> group by Director and count
+            IEnumerable<IGrouping<Director, Director>> grouped = moviesInVisit.SelectMany(m => m.Directors).GroupBy(a => a);
+            return grouped.Select(group => new KeyValuePair<Director, int>(group.Key, group.Count()));
         }
 
         public MovieWarehouseVisit GetClosestVisit()


### PR DESCRIPTION
ScanMoviesManager methods: GetCountByGenre, GetCountByActor, GetCountByDirector.

Extra: order by (count, name) descending in Program.HandleScanMoviesOptions.