### PR TITLE
ScanRips verb: allow several releasedates in option "--withreleasedate"

### DIFF
--- a/DepotTests/CRUDTests/ScanRipsManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanRipsManagerTests.cs
@@ -67,7 +67,7 @@ namespace DepotTests.CRUDTests
         public void GetAllRipsWithReleaseDate_ReturnsExpectedFileNames()
         {
             // arrange
-            string releaseDate = "1997";
+            var releaseDates = new int[] { 1997, 1998 };
             var movieRips = new List<MovieRip>() {
                     new MovieRip() {
                         FileName = "Face.Off.1997.iNTERNAL.1080p.BluRay.x264-MARS[rarbg]",
@@ -89,7 +89,7 @@ namespace DepotTests.CRUDTests
 
 
             // act
-            var ripsWithReleaseDate = this._scanRipsManager.GetAllRipsWithReleaseDate(releaseDate);
+            var ripsWithReleaseDate = this._scanRipsManager.GetAllRipsWithReleaseDate(releaseDates.ToArray());
 
             // assert
             var expected = new List<string>() {

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -109,7 +109,7 @@ namespace FilmCRUD
                 System.Console.WriteLine($"ScanRips: rips with ReleaseDate {releaseDates}\n");
                 List<string> ripFileNames = scanRipsManager.GetAllRipsWithReleaseDate(opts.WithDates.ToArray()).ToList();
 
-                System.Console.WriteLine($"Contagem: {ripFileNames.Count()}\n");
+                System.Console.WriteLine($"Total count: {ripFileNames.Count()}\n");
 
                 foreach (var fileName in ripFileNames.OrderBy(r => r))
                 {
@@ -118,7 +118,7 @@ namespace FilmCRUD
             }
             else if (opts.CountByVisit)
             {
-                System.Console.WriteLine("Scan: contagem por visita\n");
+                System.Console.WriteLine("ScanRips: count by visit \n");
                 Dictionary<DateTime, int> countByVisit = scanRipsManager.GetRipCountByVisit();
                 foreach (var item in countByVisit.OrderBy(kvp => kvp.Key))
                 {
@@ -128,7 +128,7 @@ namespace FilmCRUD
             }
             else if (opts.LastVisitDiff)
             {
-                System.Console.WriteLine("Scan: diff da última visita\n");
+                System.Console.WriteLine("ScanRips: last visit difference \n");
                 Dictionary<string, IEnumerable<string>> lastVisitDiff = scanRipsManager.GetLastVisitDiff();
                 foreach (var item in lastVisitDiff.OrderBy(kvp => kvp.Key))
                 {

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -96,17 +96,18 @@ namespace FilmCRUD
             System.Console.WriteLine("----------");
             if (opts.CountByReleaseDate)
             {
-                System.Console.WriteLine("Scan: contagem por ReleaseDate\n");
+                System.Console.WriteLine("ScanRips: count by ReleaseDate\n");
                 Dictionary<string, int> countByRelaseDate = scanRipsManager.GetRipCountByReleaseDate();
                 foreach (var kv in countByRelaseDate.OrderBy(kv => kv.Key))
                 {
                     System.Console.WriteLine($"{kv.Key}: {kv.Value}");
                 }
             }
-            else if (opts.WithReleaseDate != null)
+            else if (opts.WithDates != null)
             {
-                System.Console.WriteLine($"Scan: rips com ReleaseDate {opts.WithReleaseDate}\n");
-                List<string> ripFileNames = scanRipsManager.GetAllRipsWithReleaseDate(opts.WithReleaseDate).ToList();
+                string releaseDates = string.Join(" or ", opts.WithDates);
+                System.Console.WriteLine($"ScanRips: rips with ReleaseDate {releaseDates}\n");
+                List<string> ripFileNames = scanRipsManager.GetAllRipsWithReleaseDate(opts.WithDates.ToArray()).ToList();
 
                 System.Console.WriteLine($"Contagem: {ripFileNames.Count()}\n");
 

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -260,6 +260,7 @@ namespace FilmCRUD
             }
             System.Console.WriteLine();
         }
+
         private static async Task HandleLinkOptions(LinkOptions opts, RipToMovieLinker ripToMovieLinker)
         {
             System.Console.WriteLine("-------------");

--- a/FilmCRUD/ScanRipsManager.cs
+++ b/FilmCRUD/ScanRipsManager.cs
@@ -31,11 +31,12 @@ namespace FilmCRUD
             return result;
         }
 
-        public IEnumerable<string> GetAllRipsWithReleaseDate(string releaseDate)
+        public IEnumerable<string> GetAllRipsWithReleaseDate(params int[] dates)
         {
+            string[] dateStrings = dates.Select(d => d.ToString()).ToArray();
             MovieWarehouseVisit latestVisit = unitOfWork.MovieWarehouseVisits.GetClosestMovieWarehouseVisit();
             return latestVisit.MovieRips
-                .Where(r => r.ParsedReleaseDate == releaseDate.Trim())
+                .Where(r => dateStrings.Contains(r.ParsedReleaseDate))
                 .Select(r => r.FileName);
         }
 

--- a/FilmCRUD/Verbs/ScanRipsOptions.cs
+++ b/FilmCRUD/Verbs/ScanRipsOptions.cs
@@ -1,4 +1,5 @@
 using CommandLine;
+using System.Collections.Generic;
 
 namespace FilmCRUD.Verbs
 {
@@ -11,8 +12,8 @@ namespace FilmCRUD.Verbs
         [Option(SetName = "CountRipsByReleaseDate", HelpText = "rip count by parsed release date for latest visit")]
         public bool CountByReleaseDate { get; set; }
 
-        [Option(SetName = "GetRipsByReleaseDate", HelpText = "get all rips from last visit with releasedate YYYYMMDD")]
-        public string WithReleaseDate { get; set; }
+        [Option(SetName = "GetRipsWithReleaseDates", HelpText = "list movies with parsed released dates YYYY")]
+        public IEnumerable<int> WithDates { get; set; }
 
         [Option(SetName = "CountRipsByVisit", HelpText = "rip count by visit")]
         public bool CountByVisit { get; set; }


### PR DESCRIPTION
Similar to option ScanMoviesOptions.WithDates.

- change name: "withreleasedate" to "withdates"
- change type to IEnumerable<int>
- amend ScanRipsManager.GetAllRipsWithReleaseDate
- amend test GetAllRipsWithReleaseDate_ReturnsExpectedFileNames
- amend Program.HandleScanRipsOptions