### PR TITLE
Movie api clients: add request rate limit

### DIFF
--- a/DepotTests/UnitTest1.cs
+++ b/DepotTests/UnitTest1.cs
@@ -3,15 +3,93 @@ using Xunit;
 using MovieAPIClients.TheMovieDb;
 using ConfigUtils;
 using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using Polly;
+using Polly.Retry;
+using Polly.RateLimit;
+using Polly.Wrap;
 
 namespace DepotTests
 {
+    public class RetryWithLimitTests
+    {
+        public int MethodCallCount = 0;
+
+        public async Task<string> MyRateLimitedMethodAsync()
+        {
+            await Task.Delay(50);
+
+            this.MethodCallCount += 1;
+
+            return DateTime.Now.ToString("T");
+        }
+
+        public async Task<IEnumerable<string>> MethodWithRetriesAsync()
+        {
+            AsyncRateLimitPolicy limitPolicy = Policy.RateLimitAsync(
+                1,
+                TimeSpan.FromSeconds(1));
+
+            AsyncRetryPolicy retryPolicy = Policy
+                .Handle<RateLimitRejectedException>()
+                .WaitAndRetryAsync(new TimeSpan[] {
+                    TimeSpan.FromMilliseconds(20),
+                    TimeSpan.FromMilliseconds(40),
+                    TimeSpan.FromMilliseconds(25) });
+
+            AsyncPolicyWrap policyWrap = Policy.WrapAsync(retryPolicy, limitPolicy);
+
+            var resultList = new List<string>();
+
+            for (int i = 0; i < 5; i++)
+            {
+                try
+                {
+                    var resultThis = await policyWrap.ExecuteAsync(() => MyRateLimitedMethodAsync());
+                    resultList.Add(resultThis);
+                }
+                catch (RateLimitRejectedException)
+                {
+
+                    resultList.Add($"iter: {i}, dt: {DateTime.Now}");
+                }
+                
+            }
+
+            return resultList;
+        }
+    }
+
+
     public class UnitTest1
     {
         [Fact]
-        public void Test1()
+        public async Task Test1()
         {
+            //var dummyClient = new TheMovieDbAPIClientRateLimited("dummyKey");
+            //string x = this.GetType().FullName;
+
+            //await dummyClient.DummyExecutionsAsync();
+
+            //{ }
+
+            await Task.Delay(101);
 
         }
+
+
+        [Fact]
+        public async Task MethodWithRetriesAsyncTests()
+        {
+            var testObj = new RetryWithLimitTests();
+            var result = await testObj.MethodWithRetriesAsync();
+            
+            var callCount = testObj.MethodCallCount;
+            { }
+        }
+
+
     }
 }

--- a/FilmCRUD/Verbs/ScanRipsOptions.cs
+++ b/FilmCRUD/Verbs/ScanRipsOptions.cs
@@ -23,7 +23,7 @@ namespace FilmCRUD.Verbs
         public bool LastVisitDiff { get; set; }
 
         [Option(SetName = "VisitRipDifference", Separator = ':',
-            HelpText = "movie rip difference between two visits with dates YYYY: added and removed movie rips; example: 20100101:20100102")]
+            HelpText = "movie rip difference between two visits with dates YYYYMMDD: added and removed movie rips; example: 20100101:20100102")]
         public IEnumerable<string> VisitDiff { get; set; }
 
         [Option('l', "listvisits", SetName = "ListVisitsOption", HelpText = "helper; list dates for all visits")]

--- a/MovieAPIClients/MovieAPIClients.csproj
+++ b/MovieAPIClients/MovieAPIClients.csproj
@@ -4,6 +4,10 @@
     <ProjectReference Include="..\FilmDomain\FilmDomain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Polly" Version="7.2.3" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>

--- a/MovieAPIClients/TheMovieDb/TheMovieDbAPIClientRateLimited.cs
+++ b/MovieAPIClients/TheMovieDb/TheMovieDbAPIClientRateLimited.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Net.Http;
+
+namespace MovieAPIClients.TheMovieDb
+{
+    public class TheMovieDbAPIClientRateLimited
+    {
+        private string _apiKey { get; init; }
+
+        private HttpClient _httpClient { get; init; }
+
+        public const string MovieDbBaseAddress = "https://api.themoviedb.org/3/";
+
+        public TheMovieDbAPIClientRateLimited(string apiKey)
+        {
+            this._apiKey = apiKey;
+            HttpClient client = new();
+            client.BaseAddress = new Uri(MovieDbBaseAddress);
+            this._httpClient = client;
+        }
+    }
+}

--- a/MovieAPIClients/TheMovieDb/TheMovieDbAPIClientRateLimited.cs
+++ b/MovieAPIClients/TheMovieDb/TheMovieDbAPIClientRateLimited.cs
@@ -109,6 +109,7 @@ namespace MovieAPIClients.TheMovieDb
                 perTimeSpan
 
                 );
+
         }
     }
 }

--- a/MovieAPIClients/TheMovieDb/TheMovieDbAPIClientRateLimited.cs
+++ b/MovieAPIClients/TheMovieDb/TheMovieDbAPIClientRateLimited.cs
@@ -1,5 +1,13 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Net;
+using Polly;
+using Polly.Retry;
+using Polly.RateLimit;
 
 namespace MovieAPIClients.TheMovieDb
 {
@@ -17,6 +25,69 @@ namespace MovieAPIClients.TheMovieDb
             HttpClient client = new();
             client.BaseAddress = new Uri(MovieDbBaseAddress);
             this._httpClient = client;
+        }
+
+        public async Task<IEnumerable<MovieGenreResult>> GetMovieGenresAsync(int externalId)
+        {
+            string resultString = await _httpClient.GetStringAsync($"movie/{externalId}?api_key={_apiKey}");
+            return JsonSerializer.Deserialize<MovieGenresResultTMDB>(resultString).Genres.Select(g => (MovieGenreResult)g);
+        }
+
+        public async Task<Tuple<string, string>> GetMovieInfoAsync(int externalId)
+        {
+            var resultString = await _httpClient.GetStringAsync($"movie/{externalId}?api_key={_apiKey}");
+            var resultDict = JsonSerializer.Deserialize<Dictionary<string, object>>(resultString);
+            (string, string) result = (
+                resultDict["title"].ToString(),
+                resultDict["release_date"].ToString()
+            );
+            return result.ToTuple<string, string>();
+        }
+
+        public async Task<string> DummyExecutionsAsync(int i)
+        {
+            AsyncRateLimitPolicy<string> limitPolicy = GetRateLimitPolicy<string>(1, TimeSpan.FromSeconds(1));
+            var errors = new List<string>();
+            string result;
+            try
+            {
+                result = await limitPolicy.ExecuteAsync(async () => {
+                    await Task.Delay(2);
+                    return i.ToString();
+                });
+            }
+            catch (RateLimitRejectedException ex)
+            {
+                throw;
+            }
+            return result;
+        }
+
+        public async Task<IEnumerable<MovieGenreResult>> GetMovieGenresWithRetryAsync(int externalId)
+        {
+            AsyncRetryPolicy retryPolicy = GetAsyncRetryPolicy();
+
+            Func<Task<string>> f = () => _httpClient.GetStringAsync($"movie/{externalId}?api_key={_apiKey}");
+            string resultString = await retryPolicy.ExecuteAsync<string>(f);
+
+            return JsonSerializer.Deserialize<MovieGenresResultTMDB>(resultString).Genres.Select(g => (MovieGenreResult)g);
+        }
+
+        private static AsyncRetryPolicy GetAsyncRetryPolicy()
+        {
+            var retryPolicy = Policy
+                .Handle<HttpRequestException>(exc => exc.StatusCode == HttpStatusCode.NotFound)
+                .WaitAndRetryAsync(new[]
+                    {
+                        TimeSpan.FromSeconds(2),
+                        TimeSpan.FromSeconds(4),
+                    });
+            return retryPolicy;
+        }
+
+        private static AsyncRateLimitPolicy<TResult> GetRateLimitPolicy<TResult>(int numberOfExecutions, TimeSpan perTimeSpan)
+        {
+            return Policy.RateLimitAsync<TResult>(numberOfExecutions, perTimeSpan);
         }
     }
 }


### PR DESCRIPTION
To investigate: https://github.com/App-vNext/Polly
example: https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly