### PR TITLE
ScanMoviesOptions verb: add visit diff option

### DIFF
--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -14,6 +14,7 @@ namespace DepotTests.CRUDTests
 {
     public class ScanMoviesManagerTests
     {
+        private readonly Mock<IMovieWarehouseVisitRepository> _movieWarehouseVisitRepositoryMock;
         private readonly Mock<IMovieRepository> _movieRepositoryMock;
 
         private readonly Mock<IUnitOfWork> _unitOfWorkMock;
@@ -23,8 +24,12 @@ namespace DepotTests.CRUDTests
         public ScanMoviesManagerTests()
         {
             this._movieRepositoryMock = new Mock<IMovieRepository>(MockBehavior.Strict);
+            this._movieWarehouseVisitRepositoryMock = new Mock<IMovieWarehouseVisitRepository>(MockBehavior.Strict);
 
             this._unitOfWorkMock = new Mock<IUnitOfWork>();
+            this._unitOfWorkMock
+                .SetupGet(u => u.MovieWarehouseVisits)
+                .Returns(this._movieWarehouseVisitRepositoryMock.Object);
             this._unitOfWorkMock
                 .SetupGet(u => u.Movies)
                 .Returns(this._movieRepositoryMock.Object);
@@ -397,6 +402,73 @@ namespace DepotTests.CRUDTests
             {
                 visitDiff["removed"].Should().BeEquivalentTo(removedExpected);
                 visitDiff["added"].Should().BeEquivalentTo(addedExpected);
+            }
+        }
+
+        [Fact]
+        public void GetLastVisitDiff_ShouldReturnCorrectDifference()
+        {
+            // arrange
+            var movieWithTwoRips = new Movie() { Title = "Wake In Fright", ReleaseDate = 1971 };
+            var movieRip0 = new MovieRip() {
+                FileName = "Gummo.1997.DVDRip.XviD-DiSSOLVE",
+                Movie = new Movie() { Title = "Gummo", ReleaseDate = 1997 }
+            };
+            var movieRip1 = new MovieRip() {
+                FileName = "Papillon.1973.1080p.BluRay.X264-AMIABLE",
+                Movie = new Movie() { Title = "Papillon", ReleaseDate = 1973 }
+            };
+            var movieRip2 = new MovieRip() {
+                FileName = "Wake.In.Fright.1971.1080p.BluRay.H264.AAC-RARBG",
+                Movie = movieWithTwoRips
+            };
+            var movieRip3 = new MovieRip() {
+                FileName = "Wake.In.Fright.1971.1080p.BluRay.x264.DD2.0-FGT",
+                Movie = movieWithTwoRips
+            };
+            var movieRip4 = new MovieRip() {
+                FileName = "Badlands.1973.1080p.BluRay.X264-AMIABLE",
+                Movie = new Movie() { Title = "Badlands", ReleaseDate = 1973 }
+            };
+
+            var firstVisit = new MovieWarehouseVisit() {
+                MovieRips = new List<MovieRip>() { movieRip0, movieRip1 },
+                VisitDateTime = DateTime.ParseExact("20220101", "yyyyMMdd", null)
+            };
+            var secondVisit = new MovieWarehouseVisit() {
+                MovieRips = new List<MovieRip>() { movieRip1, movieRip2 },
+                VisitDateTime = DateTime.ParseExact("20220102", "yyyyMMdd", null)
+            };
+            var thirdVisit = new MovieWarehouseVisit() {
+                MovieRips = new List<MovieRip>() { movieRip3, movieRip4 },
+                VisitDateTime = DateTime.ParseExact("20220103", "yyyyMMdd", null)
+            };
+
+            this._movieWarehouseVisitRepositoryMock
+                .Setup(m => m.GetClosestMovieWarehouseVisit())
+                .Returns(thirdVisit);
+            this._movieWarehouseVisitRepositoryMock
+                .Setup(m => m.GetPreviousMovieWarehouseVisit(It.Is<MovieWarehouseVisit>(v => v.VisitDateTime == thirdVisit.VisitDateTime)))
+                .Returns(secondVisit);
+
+            this._movieRepositoryMock
+                .Setup(m => m.GetAllMoviesInVisit(firstVisit))
+                .Returns(firstVisit.MovieRips.Select(mr => mr.Movie));
+            this._movieRepositoryMock
+                .Setup(m => m.GetAllMoviesInVisit(secondVisit))
+                .Returns(secondVisit.MovieRips.Select(mr => mr.Movie));
+            this._movieRepositoryMock
+                .Setup(m => m.GetAllMoviesInVisit(thirdVisit))
+                .Returns(thirdVisit.MovieRips.Select(mr => mr.Movie));
+
+            // act
+            Dictionary<string, IEnumerable<string>> lastVisitDiff = this._scanMoviesManager.GetLastVisitDiff();
+
+            // assert
+            using (new AssertionScope())
+            {
+                lastVisitDiff["removed"].Should().BeEquivalentTo(new string[] { movieRip1.Movie.ToString() });
+                lastVisitDiff["added"].Should().BeEquivalentTo(new string[] { movieRip4.Movie.ToString() });
             }
         }
 

--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -14,12 +14,6 @@ namespace DepotTests.CRUDTests
 {
     public class ScanMoviesManagerTests
     {
-        private readonly Mock<IActorRepository> _actorRepositoryMock;
-
-        private readonly Mock<IGenreRepository> _genreRepositoryMock;
-
-        private readonly Mock<IDirectorRepository> _directorRepositoryMock;
-
         private readonly Mock<IMovieRepository> _movieRepositoryMock;
 
         private readonly Mock<IUnitOfWork> _unitOfWorkMock;
@@ -28,21 +22,9 @@ namespace DepotTests.CRUDTests
 
         public ScanMoviesManagerTests()
         {
-            this._actorRepositoryMock = new Mock<IActorRepository>(MockBehavior.Strict);
-            this._genreRepositoryMock = new Mock<IGenreRepository>(MockBehavior.Strict);
-            this._directorRepositoryMock = new Mock<IDirectorRepository>(MockBehavior.Strict);
             this._movieRepositoryMock = new Mock<IMovieRepository>(MockBehavior.Strict);
 
             this._unitOfWorkMock = new Mock<IUnitOfWork>();
-            this._unitOfWorkMock
-                .SetupGet(u => u.Actors)
-                .Returns(this._actorRepositoryMock.Object);
-            this._unitOfWorkMock
-                .SetupGet(u => u.Genres)
-                .Returns(this._genreRepositoryMock.Object);
-            this._unitOfWorkMock
-                .SetupGet(u => u.Directors)
-                .Returns(this._directorRepositoryMock.Object);
             this._unitOfWorkMock
                 .SetupGet(u => u.Movies)
                 .Returns(this._movieRepositoryMock.Object);

--- a/DepotTests/CRUDTests/ScanRipsManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanRipsManagerTests.cs
@@ -202,7 +202,6 @@ namespace DepotTests.CRUDTests
         public void GetVisitDiff_WithTwoVisits_ShouldReturnCorrectDifference()
         {
             // arrange
-            // arrange
             var movieRipsFirstVisit = new List<MovieRip>() {
                 new MovieRip() {
                     FileName = "Face.Off.1997.iNTERNAL.1080p.BluRay.x264-MARS[rarbg]",

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -272,6 +272,11 @@ namespace FilmCRUD
                     searchResult.ToList().ForEach(m => System.Console.WriteLine("-------------" + '\n' + m.PrettyFormat()));
                 }
             }
+            else if (opts.VisitDiff.Any())
+            {
+                // TODO: move the code in HandleScanRipsOptions to a separate method and use in both places!!
+                throw new NotImplementedException("");
+            }
             else
             {
                 System.Console.WriteLine("No action requested...");

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -258,6 +258,10 @@ namespace FilmCRUD
                     searchResult.ToList().ForEach(m => System.Console.WriteLine("-------------" + '\n' + m.PrettyFormat()));
                 }
             }
+            else if (opts.LastVisitDiff)
+            {
+                PrintVisitDiff(scanMoviesManager.GetLastVisitDiff());
+            }
             else if (opts.VisitDiff.Any())
             {
                 GetVisitDiffAndPrint(

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -260,8 +260,11 @@ namespace FilmCRUD
             }
             else if (opts.VisitDiff.Any())
             {
-                // TODO: move the code in HandleScanRipsOptions to a separate method and use in both places!!
-                throw new NotImplementedException("");
+                GetVisitDiffAndPrint(
+                    scanMoviesManager,
+                    opts.VisitDiff,
+                    visitDiffStrategy: scanMoviesManager.GetVisitDiff,
+                    printDateFormat: printDateFormat);
             }
             else
             {

--- a/FilmCRUD/ScanMoviesManager.cs
+++ b/FilmCRUD/ScanMoviesManager.cs
@@ -101,6 +101,13 @@ namespace FilmCRUD
             return this.unitOfWork.Directors.GetDirectorsFromName(name);
         }
 
+        public Dictionary<string, IEnumerable<string>> GetLastVisitDiff()
+        {
+            MovieWarehouseVisit lastVisit = this.unitOfWork.MovieWarehouseVisits.GetClosestMovieWarehouseVisit();
+            MovieWarehouseVisit previousVisit = this.unitOfWork.MovieWarehouseVisits.GetPreviousMovieWarehouseVisit(lastVisit);
+            return GetVisitDiff(previousVisit, lastVisit);
+        }
+
         /// <summary>
         /// Method <c>GetVisitDiff</c> considers all the distinct Movie entities linked to some
         /// MovieRip in <paramref name="visitLeft"/> or in <paramref name="visitLeft"/> and outputs the difference in

--- a/FilmCRUD/Verbs/ScanMoviesOptions.cs
+++ b/FilmCRUD/Verbs/ScanMoviesOptions.cs
@@ -34,7 +34,7 @@ namespace FilmCRUD.Verbs
         public bool ListVisits { get; set; }
 
         // can be used with any set, not relevant for ListVisitsOption
-        [Option('v', "visit", HelpText = "warehouse visit date (YYYY) to use as the scan target; defaults to the most recent visit")]
+        [Option('v', "visit", HelpText = "warehouse visit date (YYYYMMDD) to use as the scan target; defaults to the most recent visit")]
         public string Visit { get; set; }
 
         // can be used with any set, only relevant for GetCountByGenre/Actor/Director

--- a/FilmCRUD/Verbs/ScanMoviesOptions.cs
+++ b/FilmCRUD/Verbs/ScanMoviesOptions.cs
@@ -30,6 +30,9 @@ namespace FilmCRUD.Verbs
         [Option(SetName = "ByDirectorOptions", HelpText = "get descending movie count by director")]
         public bool ByDirector { get; set; }
 
+        [Option(SetName = "LastVisitMovieDifference", HelpText = "movie difference from last two visits")]
+        public bool LastVisitDiff { get; set; }
+
         [Option(SetName = "VisitMovieDifference", Separator = ':',
             HelpText = "movie difference between two visits with dates YYYYMMDD: added and removed movie; example: 20100101:20100102")]
         public IEnumerable<string> VisitDiff { get; set; }

--- a/FilmCRUD/Verbs/ScanMoviesOptions.cs
+++ b/FilmCRUD/Verbs/ScanMoviesOptions.cs
@@ -31,7 +31,7 @@ namespace FilmCRUD.Verbs
         public bool ByDirector { get; set; }
 
         [Option(SetName = "VisitMovieDifference", Separator = ':',
-            HelpText = "movie difference between two visits with dates YYYYMMDD: added and removed movie rips; example: 20100101:20100102")]
+            HelpText = "movie difference between two visits with dates YYYYMMDD: added and removed movie; example: 20100101:20100102")]
         public IEnumerable<string> VisitDiff { get; set; }
 
         [Option(SetName = "ListVisitsOption", HelpText = "helper; list dates for all visits")]

--- a/FilmCRUD/Verbs/ScanMoviesOptions.cs
+++ b/FilmCRUD/Verbs/ScanMoviesOptions.cs
@@ -30,6 +30,10 @@ namespace FilmCRUD.Verbs
         [Option(SetName = "ByDirectorOptions", HelpText = "get descending movie count by director")]
         public bool ByDirector { get; set; }
 
+        [Option(SetName = "VisitMovieDifference", Separator = ':',
+            HelpText = "movie difference between two visits with dates YYYYMMDD: added and removed movie rips; example: 20100101:20100102")]
+        public IEnumerable<string> VisitDiff { get; set; }
+
         [Option(SetName = "ListVisitsOption", HelpText = "helper; list dates for all visits")]
         public bool ListVisits { get; set; }
 

--- a/FilmCRUD/Verbs/ScanRipsOptions.cs
+++ b/FilmCRUD/Verbs/ScanRipsOptions.cs
@@ -23,7 +23,7 @@ namespace FilmCRUD.Verbs
         public bool LastVisitDiff { get; set; }
 
         [Option(SetName = "VisitRipDifference", Separator = ':',
-            HelpText = "movie rip difference between two visits with dates YYYY: added and removed movie rips; example: 20100101:20100102")]
+            HelpText = "movie rip difference between two visits with dates YYYYMMDD: added and removed movie rips; example: 20100101:20100102")]
         public IEnumerable<string> VisitDiff { get; set; }
 
         [Option('l', "listvisits", SetName = "ListVisitsOption", HelpText = "helper; list dates for all visits")]


### PR DESCRIPTION
Visit diff example:

### **20220101 visit files:**
Kill.List.2011.720p.BluRay.X264-7SinS
Wake.In.Fright.1971.1080p.BluRay.H264.AAC-RARBG

### **20220201 visit files:**
Chinatown.1974.1080p.BluRay.X264-AMIABLE
Wake.In.Fright.1971.1080p.BluRay.x264.DD2.0-FGT


### **VISIT DIFF:**
added: chinatown
removed: kill list

**NOTE**: wake in fright was already a part of the movie collection, only the movie rip changed. So it's not part of the difference. This is the difference between the visit diff option in verbs ScanMoviesOptions and ScanRipsOptions.

-------------------
-------------------
### **TASKS**
- new method: ScanMoviesManager.GetVisitDiff
- tests for new method in ScanMoviesManagerTests
- new option in ScanMoviesOptions 
- amend Program.HandleScanMoviesOptions
