### PR TITLE
AppSettingsManager: amend ctor to find correct env

### DIFF
--- a/ConfigUtils/AppSettingsManager.cs
+++ b/ConfigUtils/AppSettingsManager.cs
@@ -16,9 +16,7 @@ namespace ConfigUtils
             var cwd = Directory.GetCurrentDirectory();
 
             IConfigurationBuilder configBuilder = new ConfigurationBuilder();
-            configBuilder
-                .SetBasePath(cwd)
-                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
+            configBuilder.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
 
             IEnumerable<string> appSettingsEnvs = Directory
                 .GetFiles(cwd, "appsettings.*.json")

--- a/ConfigUtils/AppSettingsManager.cs
+++ b/ConfigUtils/AppSettingsManager.cs
@@ -167,4 +167,5 @@ namespace ConfigUtils
             };
         }
     }
+
 }


### PR DESCRIPTION
Should no longer rely on the FILMCRUD_ENVIRONMENT env var.

App directory should contain exactly one of these sets of files:

appsettings.json

OR

appsettings.json
appsettings.Development.json

OR

appsettings.json
appsettings.Production.json

------------------
Extra: user secrets should not be used outside DEV env.