### PR TITLE
Remove unused IFileSystemIOWrapper property

### DIFF
--- a/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
@@ -25,8 +25,6 @@ namespace DepotTests.CRUDTests
 
         private readonly Mock<IUnitOfWork> _unitOfWorkMock;
 
-        private readonly Mock<IFileSystemIOWrapper> _fileSystemIOWrapperMock;
-
         private readonly Mock<IRateLimitPolicyConfig> _rateLimitConfigMock;
 
         private readonly Mock<IRetryPolicyConfig> _retryConfigMock;
@@ -50,8 +48,6 @@ namespace DepotTests.CRUDTests
                 .SetupGet(u => u.Actors)
                 .Returns(this._actorRepositoryMock.Object);
 
-            this._fileSystemIOWrapperMock = new Mock<IFileSystemIOWrapper>();
-
             this._rateLimitConfigMock = new Mock<IRateLimitPolicyConfig>();
             this._retryConfigMock = new Mock<IRetryPolicyConfig>();
 
@@ -71,7 +67,6 @@ namespace DepotTests.CRUDTests
 
             this._movieDetailsFetcherActors = new MovieDetailsFetcherActors(
                 this._unitOfWorkMock.Object,
-                this._fileSystemIOWrapperMock.Object,
                 this._appSettingsManagerMock.Object,
                 this._movieAPIClientMock.Object);
         }

--- a/DepotTests/CRUDTests/MovieDetailsFetcherDirectorsTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherDirectorsTests.cs
@@ -25,8 +25,6 @@ namespace DepotTests.CRUDTests
 
         private readonly Mock<IUnitOfWork> _unitOfWorkMock;
 
-        private readonly Mock<IFileSystemIOWrapper> _fileSystemIOWrapperMock;
-
         private readonly Mock<IRateLimitPolicyConfig> _rateLimitConfigMock;
 
         private readonly Mock<IRetryPolicyConfig> _retryConfigMock;
@@ -50,8 +48,6 @@ namespace DepotTests.CRUDTests
                 .SetupGet(u => u.Directors)
                 .Returns(this._directorRepositoryMock.Object);
 
-            this._fileSystemIOWrapperMock = new Mock<IFileSystemIOWrapper>();
-
             this._rateLimitConfigMock = new Mock<IRateLimitPolicyConfig>();
             this._retryConfigMock = new Mock<IRetryPolicyConfig>();
 
@@ -71,7 +67,6 @@ namespace DepotTests.CRUDTests
 
             this._movieDetailsFetcherDirectors = new MovieDetailsFetcherDirectors(
                 this._unitOfWorkMock.Object,
-                this._fileSystemIOWrapperMock.Object,
                 this._appSettingsManagerMock.Object,
                 this._movieAPIClientMock.Object);
         }

--- a/DepotTests/CRUDTests/MovieDetailsFetcherGenresTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherGenresTests.cs
@@ -25,8 +25,6 @@ namespace DepotTests.CRUDTests
 
         private readonly Mock<IUnitOfWork> _unitOfWorkMock;
 
-        private readonly Mock<IFileSystemIOWrapper> _fileSystemIOWrapperMock;
-
         private readonly Mock<IRateLimitPolicyConfig> _rateLimitConfigMock;
 
         private readonly Mock<IRetryPolicyConfig> _retryConfigMock;
@@ -50,8 +48,6 @@ namespace DepotTests.CRUDTests
                 .SetupGet(u => u.Genres)
                 .Returns(this._genreRepositoryMock.Object);
 
-            this._fileSystemIOWrapperMock = new Mock<IFileSystemIOWrapper>();
-
             this._rateLimitConfigMock = new Mock<IRateLimitPolicyConfig>();
             this._retryConfigMock = new Mock<IRetryPolicyConfig>();
 
@@ -71,7 +67,6 @@ namespace DepotTests.CRUDTests
 
             this._movieDetailsFetcherGenres = new MovieDetailsFetcherGenres(
                 this._unitOfWorkMock.Object,
-                this._fileSystemIOWrapperMock.Object,
                 this._appSettingsManagerMock.Object,
                 this._movieAPIClientMock.Object);
         }

--- a/DepotTests/CRUDTests/RipToMovieLinkerTests.cs
+++ b/DepotTests/CRUDTests/RipToMovieLinkerTests.cs
@@ -29,8 +29,6 @@ namespace DepotTests.CRUDTests
 
         private readonly Mock<IUnitOfWork> _unitOfWorkMock;
 
-        private readonly Mock<IFileSystemIOWrapper> _fileSystemIOWrapperMock;
-
         private readonly Mock<IMovieAPIClient> _movieAPIClientMock;
 
         private readonly Mock<IRateLimitPolicyConfig> _rateLimitConfigMock;
@@ -53,8 +51,6 @@ namespace DepotTests.CRUDTests
             this._unitOfWorkMock
                 .SetupGet(u => u.Movies)
                 .Returns(this._movieRepositoryMock.Object);
-
-            this._fileSystemIOWrapperMock = new Mock<IFileSystemIOWrapper>();
             
             this._movieAPIClientMock = new Mock<IMovieAPIClient>(MockBehavior.Strict);
             this._movieAPIClientMock.SetupGet(m => m.ApiBaseAddress).Returns("https://api.dummy.org/");
@@ -76,7 +72,6 @@ namespace DepotTests.CRUDTests
 
             this._ripToMovieLinker = new RipToMovieLinker(
                 this._unitOfWorkMock.Object,
-                this._fileSystemIOWrapperMock.Object,
                 this._appSettingsManagerMock.Object,
                 this._movieAPIClientMock.Object);
         }

--- a/FilmCRUD/MovieDetailsFetcherAbstract.cs
+++ b/FilmCRUD/MovieDetailsFetcherAbstract.cs
@@ -16,7 +16,6 @@ using FilmDomain.Interfaces;
 using MovieAPIClients.Interfaces;
 using FilmCRUD.Helpers;
 
-
 namespace FilmCRUD
 {
     /// <summary>

--- a/FilmCRUD/MovieDetailsFetcherAbstract.cs
+++ b/FilmCRUD/MovieDetailsFetcherAbstract.cs
@@ -38,28 +38,23 @@ namespace FilmCRUD
 
         private readonly ILogger _fetchingErrorsLogger;
 
-        private IFileSystemIOWrapper _fileSystemIOWrapper { get; init; }
-
         private IAppSettingsManager _appSettingsManager { get; init; }
 
         public MovieDetailsFetcherAbstract(
             IUnitOfWork unitOfWork,
-            IFileSystemIOWrapper fileSystemIOWrapper,
             IAppSettingsManager appSettingsManager,
             IMovieAPIClient movieAPIClient)
         {
             this._unitOfWork = unitOfWork;
-            this._fileSystemIOWrapper = fileSystemIOWrapper;
             this._appSettingsManager = appSettingsManager;
             this._movieAPIClient = movieAPIClient;
         }
 
         public MovieDetailsFetcherAbstract(
             IUnitOfWork unitOfWork,
-            IFileSystemIOWrapper fileSystemIOWrapper,
             IAppSettingsManager appSettingsManager,
             IMovieAPIClient movieAPIClient,
-            ILogger fetchingErrorsLogger) : this(unitOfWork, fileSystemIOWrapper, appSettingsManager, movieAPIClient) => this._fetchingErrorsLogger = fetchingErrorsLogger;
+            ILogger fetchingErrorsLogger) : this(unitOfWork, appSettingsManager, movieAPIClient) => this._fetchingErrorsLogger = fetchingErrorsLogger;
 
         public abstract IEnumerable<Movie> GetMoviesWithoutDetails();
 

--- a/FilmCRUD/MovieDetailsFetcherActors.cs
+++ b/FilmCRUD/MovieDetailsFetcherActors.cs
@@ -14,18 +14,16 @@ namespace FilmCRUD
     {
         public MovieDetailsFetcherActors(
             IUnitOfWork unitOfWork,
-            IFileSystemIOWrapper fileSystemIOWrapper,
             IAppSettingsManager appSettingsManager,
             IMovieAPIClient movieAPIClient)
-            : base(unitOfWork, fileSystemIOWrapper, appSettingsManager, movieAPIClient) { }
+            : base(unitOfWork, appSettingsManager, movieAPIClient) { }
 
         public MovieDetailsFetcherActors(
             IUnitOfWork unitOfWork,
-            IFileSystemIOWrapper fileSystemIOWrapper,
             IAppSettingsManager appSettingsManager,
             IMovieAPIClient movieAPIClient,
             ILogger fetchingErrorsLogger)
-            : base(unitOfWork, fileSystemIOWrapper, appSettingsManager, movieAPIClient, fetchingErrorsLogger) { }
+            : base(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger) { }
 
         public override IEnumerable<Actor> GetExistingDetailEntitiesInRepo() => this._unitOfWork.Actors.GetAll();
 

--- a/FilmCRUD/MovieDetailsFetcherDirectors.cs
+++ b/FilmCRUD/MovieDetailsFetcherDirectors.cs
@@ -14,18 +14,16 @@ namespace FilmCRUD
     {
         public MovieDetailsFetcherDirectors(
             IUnitOfWork unitOfWork,
-            IFileSystemIOWrapper fileSystemIOWrapper,
             IAppSettingsManager appSettingsManager,
             IMovieAPIClient movieAPIClient)
-            : base(unitOfWork, fileSystemIOWrapper, appSettingsManager, movieAPIClient) { }
+            : base(unitOfWork, appSettingsManager, movieAPIClient) { }
 
         public MovieDetailsFetcherDirectors(
             IUnitOfWork unitOfWork,
-            IFileSystemIOWrapper fileSystemIOWrapper,
             IAppSettingsManager appSettingsManager,
             IMovieAPIClient movieAPIClient,
             ILogger fetchingErrorsLogger)
-            : base(unitOfWork, fileSystemIOWrapper, appSettingsManager, movieAPIClient, fetchingErrorsLogger) { }
+            : base(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger) { }
 
         public override IEnumerable<Director> GetExistingDetailEntitiesInRepo() => this._unitOfWork.Directors.GetAll();
 

--- a/FilmCRUD/MovieDetailsFetcherGenres.cs
+++ b/FilmCRUD/MovieDetailsFetcherGenres.cs
@@ -14,18 +14,16 @@ namespace FilmCRUD
     {
         public MovieDetailsFetcherGenres(
             IUnitOfWork unitOfWork,
-            IFileSystemIOWrapper fileSystemIOWrapper,
             IAppSettingsManager appSettingsManager,
             IMovieAPIClient movieAPIClient)
-            : base(unitOfWork, fileSystemIOWrapper, appSettingsManager, movieAPIClient) { }
+            : base(unitOfWork, appSettingsManager, movieAPIClient) { }
 
         public MovieDetailsFetcherGenres(
             IUnitOfWork unitOfWork,
-            IFileSystemIOWrapper fileSystemIOWrapper,
             IAppSettingsManager appSettingsManager,
             IMovieAPIClient movieAPIClient,
             ILogger fetchingErrorsLogger)
-            : base(unitOfWork, fileSystemIOWrapper, appSettingsManager, movieAPIClient, fetchingErrorsLogger) { }
+            : base(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger) { }
 
         public override IEnumerable<Genre> GetExistingDetailEntitiesInRepo() => this._unitOfWork.Genres.GetAll();
 

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -370,7 +370,6 @@ namespace FilmCRUD
 
             var ripToMovieLinker = new RipToMovieLinker(
                 serviceProvider.GetRequiredService<IUnitOfWork>(),
-                serviceProvider.GetRequiredService<IFileSystemIOWrapper>(),
                 serviceProvider.GetRequiredService<IAppSettingsManager>(),
                 serviceProvider.GetRequiredService<IMovieAPIClient>(),
                 linkingErrorsLogger);

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -425,7 +425,6 @@ namespace FilmCRUD
             }
 
             IUnitOfWork unitOfWork = serviceProvider.GetRequiredService<IUnitOfWork>();
-            IFileSystemIOWrapper fileSystemIOWrapper = serviceProvider.GetRequiredService<IFileSystemIOWrapper>();
             IAppSettingsManager appSettingsManager = serviceProvider.GetRequiredService<IAppSettingsManager>();
             IMovieAPIClient movieAPIClient = serviceProvider.GetRequiredService<IMovieAPIClient>();
 
@@ -437,21 +436,21 @@ namespace FilmCRUD
             if (opts.Genres)
             {
                 ILogger fetchingErrorsLogger = GetLoggerForFetchingErrors("logs/fetching_errors_genres_.txt");
-                var genresFetcher = new MovieDetailsFetcherGenres(unitOfWork, fileSystemIOWrapper, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
+                var genresFetcher = new MovieDetailsFetcherGenres(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
                 Log.Information("Fetching genres for movies...");
                 await genresFetcher.PopulateDetails();
             }
             else if (opts.Actors)
             {
                 ILogger fetchingErrorsLogger = GetLoggerForFetchingErrors("logs/fetching_errors_actors_.txt");
-                var actorsFetcher = new MovieDetailsFetcherActors(unitOfWork, fileSystemIOWrapper, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
+                var actorsFetcher = new MovieDetailsFetcherActors(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
                 Log.Information("Fetching actors for movies...");
                 await actorsFetcher.PopulateDetails();
             }
             else if (opts.Directors)
             {
                 ILogger fetchingErrorsLogger = GetLoggerForFetchingErrors("logs/fetching_errors_directors_.txt");
-                var directorsFetcher = new MovieDetailsFetcherDirectors(unitOfWork, fileSystemIOWrapper, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
+                var directorsFetcher = new MovieDetailsFetcherDirectors(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
                 Log.Information("Fetching directors for movies...");
                 await directorsFetcher.PopulateDetails();
             }

--- a/FilmCRUD/RipToMovieLinker.cs
+++ b/FilmCRUD/RipToMovieLinker.cs
@@ -24,8 +24,6 @@ namespace FilmCRUD
 {
     public class RipToMovieLinker
     {
-        private IFileSystemIOWrapper _fileSystemIOWrapper { get; init; }
-
         private IUnitOfWork _unitOfWork { get; init; }
 
         private IAppSettingsManager _appSettingsManager { get; init; }
@@ -36,12 +34,10 @@ namespace FilmCRUD
 
         public RipToMovieLinker(
             IUnitOfWork unitOfWork,
-            IFileSystemIOWrapper fileSystemIOWrapper,
             IAppSettingsManager appSettingsManager,
             IMovieAPIClient movieAPIClient)
         {
             this._unitOfWork = unitOfWork;
-            this._fileSystemIOWrapper = fileSystemIOWrapper;
             this._appSettingsManager = appSettingsManager;
             this._movieAPIClient = movieAPIClient;
         }
@@ -49,10 +45,9 @@ namespace FilmCRUD
 
         public RipToMovieLinker(
             IUnitOfWork unitOfWork,
-            IFileSystemIOWrapper fileSystemIOWrapper,
             IAppSettingsManager appSettingsManager,
             IMovieAPIClient movieAPIClient,
-            ILogger linkingErrorsLogger) : this(unitOfWork, fileSystemIOWrapper, appSettingsManager, movieAPIClient) => this._linkingErrorsLogger = linkingErrorsLogger;
+            ILogger linkingErrorsLogger) : this(unitOfWork, appSettingsManager, movieAPIClient) => this._linkingErrorsLogger = linkingErrorsLogger;
 
         /// <summary>
         /// Gets MovieRips not linked to a Movie, excluding RipFilenamesToIgnore and also those with ManualExternalIds


### PR DESCRIPTION
MovieDetailsFetcherAbstract and concrete subclasses
- [x] remove IFileSystemIOWrapper property 
- [x]  amend ctor
- [x]  amend tests

RipToMovieLinker
- [x]  remove IFileSystemIOWrapper property
- [x]  amend ctor
- [x]  amend tests

Program
- [x] HandleFetchOptions
- [x] HandleLinkOptions