### PR TITLE
Visit verb - amend processmanual option for pre existing rips

### DIFF
--- a/DepotTests/CRUDTests/VisitCRUDManagerTests.cs
+++ b/DepotTests/CRUDTests/VisitCRUDManagerTests.cs
@@ -366,13 +366,13 @@ namespace DepotTests.CRUDTests
 
             // assert
             MovieRip expectedRip = JsonSerializer.Deserialize<MovieRip>(JsonSerializer.Serialize(_manualMovieRipsCfg[preExistingRip.FileName]));
+            MovieRip ripInFirstVisit = firstVisit.MovieRips.FirstOrDefault();
+            MovieRip ripInSecondVisit = secondVisit.MovieRips.FirstOrDefault();
+
             using (new AssertionScope())
             {
                 firstVisit.MovieRips.Should().HaveCount(1);
                 secondVisit.MovieRips.Should().HaveCount(1);
-
-                MovieRip ripInFirstVisit = firstVisit.MovieRips.FirstOrDefault();
-                MovieRip ripInSecondVisit = secondVisit.MovieRips.FirstOrDefault();
 
                 // both visits should point to the same MovieRip instance
                 ripInFirstVisit.Should().BeSameAs(ripInSecondVisit);

--- a/DepotTests/CRUDTests/VisitCRUDManagerTests.cs
+++ b/DepotTests/CRUDTests/VisitCRUDManagerTests.cs
@@ -347,6 +347,10 @@ namespace DepotTests.CRUDTests
                 .Setup(m => m.GetAllRipsInVisit(It.Is<MovieWarehouseVisit>(v => v.VisitDateTime == secondVisit.VisitDateTime)))
                 .Returns(secondVisit.MovieRips);
 
+            this._movieRipRepositoryMock
+                .Setup(m => m.GetAll())
+                .Returns(firstVisit.MovieRips.Concat(secondVisit.MovieRips));
+
             var _manualMovieRipsCfg = new Dictionary<string, Dictionary<string, string>>()
             {
                 [preExistingRip.FileName] = new Dictionary<string, string>()

--- a/DepotTests/CRUDTests/VisitCRUDManagerTests.cs
+++ b/DepotTests/CRUDTests/VisitCRUDManagerTests.cs
@@ -87,7 +87,7 @@ namespace DepotTests.CRUDTests
             // nothing to do...
 
             // assert
-            _visitCRUDManager
+            this._visitCRUDManager
                 .Invoking(v => v.ReadWarehouseContentsAndRegisterVisit("20220101"))
                 .Should()
                 .Throw<DirectoryNotFoundException>();
@@ -134,15 +134,15 @@ namespace DepotTests.CRUDTests
                 "      ",
                 "Khrustalyov.My.Car.1998.720p.BluRay.x264-GHOULS[rarbg]"
             };
-            _appSettingsManagerMock
+            this._appSettingsManagerMock
                 .Setup(a => a.GetFilesToIgnore())
                 .Returns(filesToIgnore);
-            _fileSystemIOWrapperMock
+            this._fileSystemIOWrapperMock
                 .Setup(f => f.ReadAllLines(It.IsAny<string>()))
                 .Returns(textFileLines);
 
             // act
-            var fileNamesInVisit = _visitCRUDManager.GetMovieRipFileNamesInVisit("F:\\filepath\\does\\not\\matter.txt");
+            var fileNamesInVisit = this._visitCRUDManager.GetMovieRipFileNamesInVisit("F:\\filepath\\does\\not\\matter.txt");
 
             // assert
             string[] expected = {
@@ -166,10 +166,10 @@ namespace DepotTests.CRUDTests
                 new MovieRip() { FileName = "Khrustalyov.My.Car.1998.720p.BluRay.x264-GHOULS[rarbg]" },
                 new MovieRip() { FileName = "My.Cousin.Vinny.1992.1080p.BluRay.H264.AAC-RARBG" },
             };
-            _movieRipRepositoryMock.Setup(m => m.GetAll()).Returns(movieRipsInRepo);
-            
+            this._movieRipRepositoryMock.Setup(m => m.GetAll()).Returns(movieRipsInRepo);
+
             // no manual info
-            _appSettingsManagerMock
+            this._appSettingsManagerMock
                 .Setup(a => a.GetManualMovieRips())
                 .Returns(new Dictionary<string, Dictionary<string, string>>());
 
@@ -178,7 +178,7 @@ namespace DepotTests.CRUDTests
                 oldMovieRips,
                 newMovieRips,
                 newMovieRipsManual,
-                allParsingErrors) = _visitCRUDManager.GetMovieRipsInVisit(ripFileNamesInVisit);
+                allParsingErrors) = this._visitCRUDManager.GetMovieRipsInVisit(ripFileNamesInVisit);
 
             // assert
             using (new AssertionScope())
@@ -215,10 +215,10 @@ namespace DepotTests.CRUDTests
                     ["ParsedTitle"] = "some movie name"
                 }
             };
-            _movieRipRepositoryMock
+            this._movieRipRepositoryMock
                 .Setup(m => m.GetAll())
                 .Returns(movieRipsInRepo);
-            _appSettingsManagerMock
+            this._appSettingsManagerMock
                 .Setup(a => a.GetManualMovieRips())
                 .Returns(manualMovieRips);
 
@@ -227,7 +227,7 @@ namespace DepotTests.CRUDTests
                 oldMovieRips,
                 newMovieRips,
                 newMovieRipsManual,
-                allParsingErrors) = _visitCRUDManager.GetMovieRipsInVisit(ripFileNamesInVisit);
+                allParsingErrors) = this._visitCRUDManager.GetMovieRipsInVisit(ripFileNamesInVisit);
 
             // assert
             using (new AssertionScope())

--- a/DepotTests/CRUDTests/VisitCRUDManagerTests.cs
+++ b/DepotTests/CRUDTests/VisitCRUDManagerTests.cs
@@ -344,10 +344,6 @@ namespace DepotTests.CRUDTests
                 .Returns(new string[] { preExistingRip.FileName });
 
             this._movieRipRepositoryMock
-                .Setup(m => m.GetAllRipsInVisit(It.Is<MovieWarehouseVisit>(v => v.VisitDateTime == firstVisit.VisitDateTime)))
-                .Returns(firstVisit.MovieRips);
-            
-            this._movieRipRepositoryMock
                 .Setup(m => m.GetAllRipsInVisit(It.Is<MovieWarehouseVisit>(v => v.VisitDateTime == secondVisit.VisitDateTime)))
                 .Returns(secondVisit.MovieRips);
 

--- a/DepotTests/CRUDTests/VisitCRUDManagerTests.cs
+++ b/DepotTests/CRUDTests/VisitCRUDManagerTests.cs
@@ -378,7 +378,9 @@ namespace DepotTests.CRUDTests
                 MovieRip ripInFirstVisit = firstVisit.MovieRips.FirstOrDefault();
                 MovieRip ripInSecondVisit = secondVisit.MovieRips.FirstOrDefault();
 
+                // both visits should point to the same MovieRip instance
                 ripInFirstVisit.Should().BeSameAs(ripInSecondVisit);
+
                 ripInFirstVisit.Should().BeEquivalentTo(expectedRip);
                 ripInSecondVisit.Should().BeEquivalentTo(expectedRip);
             }

--- a/FilmCRUD/VisitCRUDManager.cs
+++ b/FilmCRUD/VisitCRUDManager.cs
@@ -174,6 +174,7 @@ namespace FilmCRUD
 
         public void ProcessManuallyProvidedMovieRipsForExistingVisit(string visitDateString)
         {
+
             DateTime visitDate = DateTime.ParseExact(visitDateString, "yyyyMMdd", null);
             if (!this._unitOfWork.MovieWarehouseVisits.GetVisitDates().Contains(visitDate))
             {

--- a/FilmCRUD/VisitCRUDManager.cs
+++ b/FilmCRUD/VisitCRUDManager.cs
@@ -174,7 +174,6 @@ namespace FilmCRUD
 
         public void ProcessManuallyProvidedMovieRipsForExistingVisit(string visitDateString)
         {
-
             DateTime visitDate = DateTime.ParseExact(visitDateString, "yyyyMMdd", null);
             if (!this._unitOfWork.MovieWarehouseVisits.GetVisitDates().Contains(visitDate))
             {


### PR DESCRIPTION
```
Unhandled exception. Microsoft.EntityFrameworkCore.DbUpdateException: An error occurred while saving the entity changes. See the inner exception for details.
 ---> Microsoft.Data.Sqlite.SqliteException (0x80004005): SQLite Error 19: 'UNIQUE constraint failed: MovieRips.FileName'.
   at Microsoft.Data.Sqlite.SqliteException.ThrowExceptionForRC(Int32 rc, sqlite3 db)
   at Microsoft.Data.Sqlite.SqliteDataReader.NextResult()
   at Microsoft.Data.Sqlite.SqliteCommand.ExecuteReader(CommandBehavior behavior)
   at Microsoft.Data.Sqlite.SqliteCommand.ExecuteDbDataReader(CommandBehavior behavior)
   at System.Data.Common.DbCommand.ExecuteReader()
   at Microsoft.EntityFrameworkCore.Storage.RelationalCommand.ExecuteReader(RelationalCommandParameterObject parameterObject)
   at Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch.Execute(IRelationalConnection connection)
   --- End of inner exception stack trace ---
   at Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch.Execute(IRelationalConnection connection)
   at Microsoft.EntityFrameworkCore.Update.Internal.BatchExecutor.Execute(IEnumerable`1 commandBatches, IRelationalConnection connection)
   at Microsoft.EntityFrameworkCore.Storage.RelationalDatabase.SaveChanges(IList`1 entries)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(IList`1 entriesToSave)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(StateManager stateManager, Boolean acceptAllChangesOnSuccess)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.<>c.<SaveChanges>b__104_0(DbContext _, ValueTuple`2 t)
   at Microsoft.EntityFrameworkCore.Storage.NonRetryingExecutionStrategy.Execute[TState,TResult](TState state, Func`3 operation, Func`3 verifySucceeded)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(Boolean acceptAllChangesOnSuccess)
   at Microsoft.EntityFrameworkCore.DbContext.SaveChanges(Boolean acceptAllChangesOnSuccess)
   at Microsoft.EntityFrameworkCore.DbContext.SaveChanges()
   at FilmDataAccess.EFCore.UnitOfWork.SQLiteUnitOfWork.Complete() in C:\Users\Miguel\dev\entertainmentdepot\FilmDataAccess.EFCore\UnitOfWork\SQLiteUnitOfWork.cs:line 35
   at FilmCRUD.VisitCRUDManager.ProcessManuallyProvidedMovieRipsForExistingVisit(String visitDateString) in C:\Users\Miguel\dev\entertainmentdepot\FilmCRUD\VisitCRUDManager.cs:line 209
   at FilmCRUD.Program.HandleVisitOptions(VisitOptions opts, ServiceProvider serviceProvider) in C:\Users\Miguel\dev\entertainmentdepot\FilmCRUD\Program.cs:line 159
   at FilmCRUD.Program.<>c__DisplayClass1_0.<Main>b__0(VisitOptions opts) in C:\Users\Miguel\dev\entertainmentdepot\FilmCRUD\Program.cs:line 59
   at CommandLine.ParserResultExtensions.WithParsed[T](ParserResult`1 result, Action`1 action)
   at FilmCRUD.Program.Main(String[] args) in C:\Users\Miguel\dev\entertainmentdepot\FilmCRUD\Program.cs:line 59
   at FilmCRUD.Program.<Main>(String[] args)
```

- [x] add testcase
- [x] amend
