### PR TITLE
FileNameParser - create regex object properties and initialize in static ctor

### DIFF
--- a/FilmCRUD/Helpers/FileNameParser.cs
+++ b/FilmCRUD/Helpers/FileNameParser.cs
@@ -35,12 +35,20 @@ namespace FilmCRUD.Helpers
 
         private const string _parenthesesOrBrackets_Right = @"\)|\]";
 
-        public static readonly Regex RipQualityMatchRegex;
+        public static readonly Regex RipQualityRegex;
+
+        public static readonly Regex ReleaseTypeRegex;
 
         // initializing Regex properties
         static FileNameParser()
         {
-            RipQualityMatchRegex = new Regex($"(({_parenthesesOrBrackets_Left})*){_ripQualitySplitter}(({_parenthesesOrBrackets_Right})*)", RegexOptions.IgnoreCase);
+            RipQualityRegex = new Regex(
+                $"(({_parenthesesOrBrackets_Left})*){_ripQualitySplitter}(({_parenthesesOrBrackets_Right})*)",
+                RegexOptions.IgnoreCase);
+
+            ReleaseTypeRegex = new Regex(
+                $"(({_parenthesesOrBrackets_Left})*){_ripReleaseTypeSplitter}(({_parenthesesOrBrackets_Right})*)",
+                RegexOptions.IgnoreCase);
         }
 
         public static (string Title, string ReleaseDate) SplitTitleAndReleaseDate(string ParsedTitleAndReleaseDate)
@@ -122,12 +130,9 @@ namespace FilmCRUD.Helpers
         {
             string parsedTitleAndReleaseDate, parsedRipInfoAndGroup, parsedRipQuality, parsedRipInfo, parsedRipGroup;
 
-            Match ripQualityMatch = RipQualityMatchRegex.Match(fileName);
+            Match ripQualityMatch = RipQualityRegex.Match(fileName);
 
-            Match releaseTypeMatch = Regex.Match(
-                fileName,
-                $"(({_parenthesesOrBrackets_Left})*){_ripReleaseTypeSplitter}(({_parenthesesOrBrackets_Right})*)",
-                RegexOptions.IgnoreCase);
+            Match releaseTypeMatch = ReleaseTypeRegex.Match(fileName);
 
             // in this case we assume that param fileName has the format "some movie (1999)" or just the movie title, details
             // are handled by method SplitTitleAndReleaseDate

--- a/FilmCRUD/Helpers/FileNameParser.cs
+++ b/FilmCRUD/Helpers/FileNameParser.cs
@@ -48,6 +48,8 @@ namespace FilmCRUD.Helpers
 
         public static readonly Regex AbsentReleaseDateRegex;
 
+        public static readonly Regex IsSurroundedRegex;
+
         // initializing Regex properties
         static FileNameParser()
         {
@@ -66,6 +68,12 @@ namespace FilmCRUD.Helpers
             ReleaseDateSplitterRegex = new Regex($"(({_parenthesesOrBrackets_Left})*){_releaseDateSplitter}(({_parenthesesOrBrackets_Right})*)");
 
             AbsentReleaseDateRegex = new Regex($"^([a-z0-9]|{_tokenSplitter})*$", RegexOptions.IgnoreCase);
+
+            string _bracesLeft = @"\{";
+            string _bracesRight = @"\}";
+            IsSurroundedRegex = new Regex(
+                $"^({_parenthesesOrBrackets_Left}|{_bracesLeft})(.*?)({_parenthesesOrBrackets_Right}|{_bracesRight})$",
+                RegexOptions.IgnoreCase);
         }
 
         public static (string Title, string ReleaseDate) SplitTitleAndReleaseDate(string ParsedTitleAndReleaseDate)
@@ -119,13 +127,7 @@ namespace FilmCRUD.Helpers
             else
             {
                 // cases like {5.1} or [5.1] or (5.1)
-                string bracesLeft = @"\{";
-                string bracesRight = @"\}";
-                bool isSurrounded = Regex.IsMatch(
-                    ripInfoAndGroup,
-                    $"^({_parenthesesOrBrackets_Left}|{bracesLeft})(.*?)({_parenthesesOrBrackets_Right}|{bracesRight})$",
-                    RegexOptions.IgnoreCase);
-                if (isSurrounded) return (ripInfoAndGroup, null);
+                if (IsSurroundedRegex.IsMatch(ripInfoAndGroup)) return (ripInfoAndGroup, null);
 
                 IEnumerable<string> splittedByTokenSplitter = Regex
                     .Split(ripInfoAndGroup, _tokenSplitter, RegexOptions.IgnoreCase);

--- a/FilmCRUD/Helpers/FileNameParser.cs
+++ b/FilmCRUD/Helpers/FileNameParser.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 using FilmDomain.Entities;
 using FilmDomain.Extensions;
 using FilmCRUD.CustomExceptions;
-
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace FilmCRUD.Helpers
 {
@@ -43,6 +43,8 @@ namespace FilmCRUD.Helpers
 
         public static readonly Regex ParenthesesOrBrackets_RightRegex;
 
+        public static readonly Regex ReleaseDateSplitterRegex;
+
         // initializing Regex properties
         static FileNameParser()
         {
@@ -57,15 +59,15 @@ namespace FilmCRUD.Helpers
             ParenthesesOrBrackets_LeftRegex = new Regex(_parenthesesOrBrackets_Left);
 
             ParenthesesOrBrackets_RightRegex = new Regex(_parenthesesOrBrackets_Right);
+
+            ReleaseDateSplitterRegex = new Regex($"(({_parenthesesOrBrackets_Left})*){_releaseDateSplitter}(({_parenthesesOrBrackets_Right})*)");
         }
 
         public static (string Title, string ReleaseDate) SplitTitleAndReleaseDate(string ParsedTitleAndReleaseDate)
         {
             ParsedTitleAndReleaseDate = ParsedTitleAndReleaseDate.Trim();
 
-            MatchCollection matches = Regex.Matches(
-                ParsedTitleAndReleaseDate,
-                $"(({_parenthesesOrBrackets_Left})*){_releaseDateSplitter}(({_parenthesesOrBrackets_Right})*)");
+            MatchCollection matches = ReleaseDateSplitterRegex.Matches(ParsedTitleAndReleaseDate);
 
             // the only admissible case without matches is when there's no release date
             if (!matches.Any())

--- a/FilmCRUD/Helpers/FileNameParser.cs
+++ b/FilmCRUD/Helpers/FileNameParser.cs
@@ -6,6 +6,7 @@ using FilmDomain.Entities;
 using FilmDomain.Extensions;
 using FilmCRUD.CustomExceptions;
 using Microsoft.EntityFrameworkCore.Metadata;
+using System.Diagnostics;
 
 namespace FilmCRUD.Helpers
 {
@@ -45,6 +46,8 @@ namespace FilmCRUD.Helpers
 
         public static readonly Regex ReleaseDateSplitterRegex;
 
+        public static readonly Regex AbsentReleaseDateRegex;
+
         // initializing Regex properties
         static FileNameParser()
         {
@@ -61,6 +64,8 @@ namespace FilmCRUD.Helpers
             ParenthesesOrBrackets_RightRegex = new Regex(_parenthesesOrBrackets_Right);
 
             ReleaseDateSplitterRegex = new Regex($"(({_parenthesesOrBrackets_Left})*){_releaseDateSplitter}(({_parenthesesOrBrackets_Right})*)");
+
+            AbsentReleaseDateRegex = new Regex($"^([a-z0-9]|{_tokenSplitter})*$", RegexOptions.IgnoreCase);
         }
 
         public static (string Title, string ReleaseDate) SplitTitleAndReleaseDate(string ParsedTitleAndReleaseDate)
@@ -72,7 +77,7 @@ namespace FilmCRUD.Helpers
             // the only admissible case without matches is when there's no release date
             if (!matches.Any())
             {
-                if (!Regex.IsMatch(ParsedTitleAndReleaseDate, $"^([a-z0-9]|{_tokenSplitter})*$", RegexOptions.IgnoreCase))
+                if (!AbsentReleaseDateRegex.IsMatch(ParsedTitleAndReleaseDate))
                 {
                     throw new FileNameParserError($"Cannot split into film title and release date: {ParsedTitleAndReleaseDate}");
                 }

--- a/FilmCRUD/Helpers/FileNameParser.cs
+++ b/FilmCRUD/Helpers/FileNameParser.cs
@@ -35,6 +35,14 @@ namespace FilmCRUD.Helpers
 
         private const string _parenthesesOrBrackets_Right = @"\)|\]";
 
+        public static readonly Regex RipQualityMatchRegex;
+
+        // initializing Regex properties
+        static FileNameParser()
+        {
+            RipQualityMatchRegex = new Regex($"(({_parenthesesOrBrackets_Left})*){_ripQualitySplitter}(({_parenthesesOrBrackets_Right})*)", RegexOptions.IgnoreCase);
+        }
+
         public static (string Title, string ReleaseDate) SplitTitleAndReleaseDate(string ParsedTitleAndReleaseDate)
         {
             ParsedTitleAndReleaseDate = ParsedTitleAndReleaseDate.Trim();
@@ -114,10 +122,7 @@ namespace FilmCRUD.Helpers
         {
             string parsedTitleAndReleaseDate, parsedRipInfoAndGroup, parsedRipQuality, parsedRipInfo, parsedRipGroup;
 
-            Match ripQualityMatch = Regex.Match(
-                fileName,
-                $"(({_parenthesesOrBrackets_Left})*){_ripQualitySplitter}(({_parenthesesOrBrackets_Right})*)",
-                RegexOptions.IgnoreCase);
+            Match ripQualityMatch = RipQualityMatchRegex.Match(fileName);
 
             Match releaseTypeMatch = Regex.Match(
                 fileName,

--- a/FilmCRUD/Helpers/FileNameParser.cs
+++ b/FilmCRUD/Helpers/FileNameParser.cs
@@ -11,6 +11,7 @@ namespace FilmCRUD.Helpers
 {
     public static class FileNameParser
     {
+
         // filename tokens will be either separated by "." or by whitespace
         private const string _tokenSplitter = @"(\.|\s)";
 

--- a/FilmCRUD/Helpers/FileNameParser.cs
+++ b/FilmCRUD/Helpers/FileNameParser.cs
@@ -50,6 +50,8 @@ namespace FilmCRUD.Helpers
 
         public static readonly Regex IsSurroundedRegex;
 
+        public static readonly Regex TokenSplitterRegex;
+
         // initializing Regex properties
         static FileNameParser()
         {
@@ -74,6 +76,8 @@ namespace FilmCRUD.Helpers
             IsSurroundedRegex = new Regex(
                 $"^({_parenthesesOrBrackets_Left}|{_bracesLeft})(.*?)({_parenthesesOrBrackets_Right}|{_bracesRight})$",
                 RegexOptions.IgnoreCase);
+
+            TokenSplitterRegex = new Regex(_tokenSplitter, RegexOptions.IgnoreCase);
         }
 
         public static (string Title, string ReleaseDate) SplitTitleAndReleaseDate(string ParsedTitleAndReleaseDate)
@@ -129,8 +133,7 @@ namespace FilmCRUD.Helpers
                 // cases like {5.1} or [5.1] or (5.1)
                 if (IsSurroundedRegex.IsMatch(ripInfoAndGroup)) return (ripInfoAndGroup, null);
 
-                IEnumerable<string> splittedByTokenSplitter = Regex
-                    .Split(ripInfoAndGroup, _tokenSplitter, RegexOptions.IgnoreCase);
+                IEnumerable<string> splittedByTokenSplitter = TokenSplitterRegex.Split(ripInfoAndGroup);
 
                 if (splittedByTokenSplitter.Count() > 1)
                 {

--- a/FilmCRUD/Helpers/FileNameParser.cs
+++ b/FilmCRUD/Helpers/FileNameParser.cs
@@ -39,6 +39,10 @@ namespace FilmCRUD.Helpers
 
         public static readonly Regex ReleaseTypeRegex;
 
+        public static readonly Regex ParenthesesOrBrackets_LeftRegex;
+
+        public static readonly Regex ParenthesesOrBrackets_RightRegex;
+
         // initializing Regex properties
         static FileNameParser()
         {
@@ -49,6 +53,10 @@ namespace FilmCRUD.Helpers
             ReleaseTypeRegex = new Regex(
                 $"(({_parenthesesOrBrackets_Left})*){_ripReleaseTypeSplitter}(({_parenthesesOrBrackets_Right})*)",
                 RegexOptions.IgnoreCase);
+
+            ParenthesesOrBrackets_LeftRegex = new Regex(_parenthesesOrBrackets_Left);
+
+            ParenthesesOrBrackets_RightRegex = new Regex(_parenthesesOrBrackets_Right);
         }
 
         public static (string Title, string ReleaseDate) SplitTitleAndReleaseDate(string ParsedTitleAndReleaseDate)
@@ -145,12 +153,10 @@ namespace FilmCRUD.Helpers
             else if (ripQualityMatch.Success)
             {
                 parsedTitleAndReleaseDate = fileName.Substring(0, length: ripQualityMatch.Index).Trim();
-                parsedRipQuality = Regex.Replace(
-                    Regex.Replace(
+                parsedRipQuality = ParenthesesOrBrackets_LeftRegex.Replace(
+                    ParenthesesOrBrackets_RightRegex.Replace(
                         ripQualityMatch.Value,
-                        _parenthesesOrBrackets_Left,
                         string.Empty),
-                    _parenthesesOrBrackets_Right,
                     string.Empty);
 
                 parsedRipInfoAndGroup = fileName.Substring(ripQualityMatch.Index + ripQualityMatch.Length).Trim('.', ' ');


### PR DESCRIPTION
Create one `Regex` object property for each string used in `Regex.Match`, `Regex.Matches`, `Regex.IsMatch `etc..

Example:

ripQualityMatchRegex: `$"(({_parenthesesOrBrackets_Left})*){_ripQualitySplitter}(({_parenthesesOrBrackets_Right})*)"`