### PR TITLE
Link verb: add option to limit the number of API calls

### DIFF
--- a/DepotTests/CRUDTests/RipToMovieLinkerTests.cs
+++ b/DepotTests/CRUDTests/RipToMovieLinkerTests.cs
@@ -916,7 +916,7 @@ namespace DepotTests.CRUDTests
                 .ReturnsAsync(false);
 
             // act
-            await this._ripToMovieLinker.ValidateManualExternalIdsAsync();
+            await this._ripToMovieLinker.ValidateManualExternalIdsAsync(maxApiCalls);
 
             // assert
             this._movieAPIClientMock.Verify(m => m.ExternalIdExistsAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));

--- a/DepotTests/CRUDTests/RipToMovieLinkerTests.cs
+++ b/DepotTests/CRUDTests/RipToMovieLinkerTests.cs
@@ -354,8 +354,10 @@ namespace DepotTests.CRUDTests
         }
 
 
-        [Fact]
-        public async Task SearchAndLinkAsync_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit()
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        public async Task SearchAndLinkAsync_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit(int maxApiCalls)
         {
             // arrange
             var firstMovieRipToLink = new MovieRip() {
@@ -390,10 +392,10 @@ namespace DepotTests.CRUDTests
                 .ReturnsAsync(new MovieSearchResult[] { dummySearchResult });
 
             // act
-            await this._ripToMovieLinker.SearchAndLinkAsync(maxApiCalls: 2);
+            await this._ripToMovieLinker.SearchAndLinkAsync(maxApiCalls);
 
             // assert
-            this._movieAPIClientMock.Verify(m => m.SearchMovieAsync(It.IsAny<string>()), Times.AtMost(2));
+            this._movieAPIClientMock.Verify(m => m.SearchMovieAsync(It.IsAny<string>()), Times.Exactly(maxApiCalls));
         }
 
 

--- a/DepotTests/CRUDTests/RipToMovieLinkerTests.cs
+++ b/DepotTests/CRUDTests/RipToMovieLinkerTests.cs
@@ -894,5 +894,32 @@ namespace DepotTests.CRUDTests
             // assert
             this._movieAPIClientMock.Verify(m => m.ExternalIdExistsAsync(It.IsAny<int>()), Times.Never);
         }
+
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        public async Task ValidateManualExternalIdsAsync_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit(int maxApiCalls)
+        {
+            // arrange
+            var manualExternalIds = new Dictionary<string, int>() {
+                { "Witchfinder.General.1968.1080p.BluRay.x264-CiNEFiLE", 101 },
+                { "Men.and.Chicken.2015.LIMITED.1080p.BluRay.x264-USURY[rarbg]", 102 },
+                { "Into.the.Wild.2007.1080p.BluRay.x264.DTS-FGT", 103 }
+            };
+            this._appSettingsManagerMock
+                .Setup(a => a.GetManualExternalIds())
+                .Returns(manualExternalIds);
+
+            this._movieAPIClientMock
+                .Setup(m => m.ExternalIdExistsAsync(It.IsAny<int>()))
+                .ReturnsAsync(false);
+
+            // act
+            await this._ripToMovieLinker.ValidateManualExternalIdsAsync();
+
+            // assert
+            this._movieAPIClientMock.Verify(m => m.ExternalIdExistsAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));
+        }
     }
 }

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -547,6 +547,7 @@ namespace FilmCRUD
                 Console.WriteLine(String.Join('\n', item.Value.OrderBy(s => s)));
             }
         }
+
     }
 
 }

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -547,7 +547,6 @@ namespace FilmCRUD
                 Console.WriteLine(String.Join('\n', item.Value.OrderBy(s => s)));
             }
         }
-
     }
 
 }

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -382,12 +382,12 @@ namespace FilmCRUD
             if (opts.Search)
             {
                 Log.Information("Linking movie rips to movies - searching...");
-                await ripToMovieLinker.SearchAndLinkAsync();
+                await ripToMovieLinker.SearchAndLinkAsync(opts.MaxCalls ?? -1);
             }
             else if (opts.FromManualExtIds)
             {
                 Log.Information($"Linking movie rips to movies - from manually configured external ids...");
-                await ripToMovieLinker.LinkFromManualExternalIdsAsync();
+                await ripToMovieLinker.LinkFromManualExternalIdsAsync(opts.MaxCalls ?? -1);
             }
             else if (opts.GetUnlinkedRips)
             {
@@ -395,12 +395,11 @@ namespace FilmCRUD
                 Console.WriteLine($"Unlinked MovieRips:");
                 Console.WriteLine();
                 unlinked.ToList().ForEach(s => Console.WriteLine(s));
-
             }
             else if (opts.ValidateManualExtIds)
             {
                 Log.Information($"Validating manually configured external ids...");
-                await ripToMovieLinker.ValidateManualExternalIdsAsync();
+                await ripToMovieLinker.ValidateManualExternalIdsAsync(opts.MaxCalls ?? -1);
             }
             else
             {

--- a/FilmCRUD/RipToMovieLinker.cs
+++ b/FilmCRUD/RipToMovieLinker.cs
@@ -105,7 +105,7 @@ namespace FilmCRUD
             return relatedMovie;
         }
 
-        public async Task SearchAndLinkAsync(int? maxApiCalls = null)
+        public async Task SearchAndLinkAsync(int maxApiCalls = -1)
         {   
             IEnumerable<MovieRip> ripsToLink = GetMovieRipsToLink();
             int totalCount = ripsToLink.Count();

--- a/FilmCRUD/RipToMovieLinker.cs
+++ b/FilmCRUD/RipToMovieLinker.cs
@@ -248,7 +248,7 @@ namespace FilmCRUD
             this._unitOfWork.Complete();
         }
 
-        public async Task LinkFromManualExternalIdsAsync()
+        public async Task LinkFromManualExternalIdsAsync(int maxApiCalls = -1)
         {
             Dictionary<string, int> allManualExternalIds = _appSettingsManager.GetManualExternalIds() ?? new Dictionary<string, int>();
 

--- a/FilmCRUD/RipToMovieLinker.cs
+++ b/FilmCRUD/RipToMovieLinker.cs
@@ -385,10 +385,7 @@ namespace FilmCRUD
             this._unitOfWork.Complete();
         }
 
-        public IEnumerable<string> GetAllUnlinkedMovieRips()
-        {
-            return this._unitOfWork.MovieRips.Find(m => m.Movie == null).GetFileNames();
-        }
+        public IEnumerable<string> GetAllUnlinkedMovieRips() => this._unitOfWork.MovieRips.Find(m => m.Movie == null).GetFileNames();
 
         public async Task ValidateManualExternalIdsAsync()
         {

--- a/FilmCRUD/RipToMovieLinker.cs
+++ b/FilmCRUD/RipToMovieLinker.cs
@@ -153,10 +153,17 @@ namespace FilmCRUD
             }
 
             int onlineSearchCount = ripsForOnlineSearch.Count;
+            Log.Information("Total count for online search: {OnlineSearchCount}", onlineSearchCount);
+
+            if (0 < maxApiCalls && maxApiCalls < onlineSearchCount)
+            {
+                Log.Information("Limiting number of rips for online search to {CallLimit}", maxApiCalls);
+                ripsForOnlineSearch = ripsForOnlineSearch.Take(maxApiCalls).ToList();
+                onlineSearchCount = maxApiCalls;
+            }
+
             var logStepOnlineSearch = (int)Math.Ceiling((decimal)onlineSearchCount / 20.0m);
             
-            Log.Information("Count for online search: {OnlineSearchCount}", onlineSearchCount);
-
             AsyncPolicyWrap policyWrap = GetPolicyWrapFromConfigs(out TimeSpan initialDelay);
 
             // letting the token bucket fill for the current timespan...

--- a/FilmCRUD/RipToMovieLinker.cs
+++ b/FilmCRUD/RipToMovieLinker.cs
@@ -387,7 +387,7 @@ namespace FilmCRUD
 
         public IEnumerable<string> GetAllUnlinkedMovieRips() => this._unitOfWork.MovieRips.Find(m => m.Movie == null).GetFileNames();
 
-        public async Task ValidateManualExternalIdsAsync()
+        public async Task ValidateManualExternalIdsAsync(int maxApiCalls = -1)
         {
             Dictionary<string, int> manualExternalIds = _appSettingsManager.GetManualExternalIds() ?? new Dictionary<string, int>();
 
@@ -397,6 +397,13 @@ namespace FilmCRUD
             {
                 Log.Information("No manually configured external ids");
                 return;
+            }
+
+            if (0 < maxApiCalls && maxApiCalls < manualExternalIdsCount)
+            {
+                Log.Information("Limiting number of API calls to {CallLimit}", maxApiCalls);
+                manualExternalIds = manualExternalIds.Take(maxApiCalls).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+                manualExternalIdsCount = maxApiCalls;
             }
 
             AsyncPolicyWrap policyWrap = GetPolicyWrapFromConfigs(out TimeSpan initialDelay);

--- a/FilmCRUD/RipToMovieLinker.cs
+++ b/FilmCRUD/RipToMovieLinker.cs
@@ -276,6 +276,13 @@ namespace FilmCRUD
 
             Log.Information("External ids for API calls - count: {ExternalIdsForApiCallsCount}", externalIdsForApiCallsCount);
 
+            if (0 < maxApiCalls && maxApiCalls < externalIdsForApiCallsCount)
+            {
+                Log.Information("Limiting number of rips for online search to {CallLimit}", maxApiCalls);
+                externalIdsForApiCalls = externalIdsForApiCalls.Take(maxApiCalls).ToList();
+                externalIdsForApiCallsCount = maxApiCalls;
+            }
+
             AsyncPolicyWrap policyWrap = GetPolicyWrapFromConfigs(out TimeSpan initialDelay);
 
             // letting the token bucket fill for the current timespan...

--- a/FilmCRUD/RipToMovieLinker.cs
+++ b/FilmCRUD/RipToMovieLinker.cs
@@ -105,7 +105,7 @@ namespace FilmCRUD
             return relatedMovie;
         }
 
-        public async Task SearchAndLinkAsync()
+        public async Task SearchAndLinkAsync(int? maxApiCalls = null)
         {   
             IEnumerable<MovieRip> ripsToLink = GetMovieRipsToLink();
             int totalCount = ripsToLink.Count();
@@ -154,7 +154,6 @@ namespace FilmCRUD
 
             int onlineSearchCount = ripsForOnlineSearch.Count;
             var logStepOnlineSearch = (int)Math.Ceiling((decimal)onlineSearchCount / 20.0m);
-
             
             Log.Information("Count for online search: {OnlineSearchCount}", onlineSearchCount);
 

--- a/FilmCRUD/Verbs/LinkOptions.cs
+++ b/FilmCRUD/Verbs/LinkOptions.cs
@@ -19,6 +19,6 @@ namespace FilmCRUD.Verbs
         public bool ValidateManualExtIds { get; set; }
 
         [Option('m', "maxcalls", HelpText = "optional integer to limit the number of API calls")]
-        public int MaxCalls { get; set; }
+        public int? MaxCalls { get; set; }
     }
 }

--- a/FilmCRUD/Verbs/LinkOptions.cs
+++ b/FilmCRUD/Verbs/LinkOptions.cs
@@ -1,12 +1,11 @@
 using CommandLine;
+using CommandLine.Text;
 
 namespace FilmCRUD.Verbs
 {
-
     [Verb("link", HelpText = "to link each movierip to a movie using online and local searches")]
     public class LinkOptions
     {
-
         [Option(SetName = "SearchLocallyAndOnline", HelpText = "search locally and online")]
         public bool Search { get; set; }
 
@@ -19,6 +18,7 @@ namespace FilmCRUD.Verbs
         [Option(SetName = "ValidateManualExternalIds", HelpText = "validate the manually configured external ids")]
         public bool ValidateManualExtIds { get; set; }
 
+        [Option('m', "maxcalls", HelpText = "optional integer to limit the number of API calls")]
+        public int MaxCalls { get; set; }
     }
-
 }


### PR DESCRIPTION
**Link** verb:
- [x] add new unittest to test new param `maxApiCalls` in method `RipToMovieLinker.SearchAndLinkAsync`
- [x] implement new param `maxApiCalls` in method `RipToMovieLinker.SearchAndLinkAsync`; include logs if it's used;
- [x] add new unittest to test new param `maxApiCalls` in method `RipToMovieLinker.LinkFromManualExternalIdsAsync`
- [x] implement new param `maxApiCalls` in method `RipToMovieLinker.LinkFromManualExternalIdsAsync`; include logs if it's used;
- [x] add new unittest to test new param `maxApiCalls` in method `RipToMovieLinker.ValidateManualExternalIdsAsync`
- [x] implement new param `maxApiCalls` in method `RipToMovieLinker.ValidateManualExternalIdsAsync`; include logs if it's used;
- [x] add new option to class `LinkOptions`: `link --search --max 25` or `link --search -m 25`
- [x] amend `Program.HandleLinkOptions` to use new option when calling methods from class `RipToMovieLinker`