### PR TITLE
Fetch verb: add option to limit the number of API calls

### DIFF
--- a/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
@@ -261,9 +261,9 @@ namespace DepotTests.CRUDTests
         public async Task PopulateDetails_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit(int maxApiCalls)
         {
             // arrange
-            var firstMovie = new Movie() { Title = "My Cousin Vinny", ReleaseDate = 1992, ExternalId = 101, Genres = new List<Genre>() };
-            var secondMovie = new Movie() { Title = "Payback", ReleaseDate = 1999, ExternalId = 102, Genres = new List<Genre>() };
-            var thirdMovie = new Movie() { Title = "Office Space", ReleaseDate = 1999, ExternalId = 103, Genres = new List<Genre>() };
+            var firstMovie = new Movie() { Title = "My Cousin Vinny", ReleaseDate = 1992, ExternalId = 101, Actors = new List<Actor>() };
+            var secondMovie = new Movie() { Title = "Payback", ReleaseDate = 1999, ExternalId = 102, Actors = new List<Actor>() };
+            var thirdMovie = new Movie() { Title = "Office Space", ReleaseDate = 1999, ExternalId = 103, Actors = new List<Actor>() };
 
             this._movieRepositoryMock
                 .Setup(m => m.GetMoviesWithoutActors())

--- a/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
@@ -255,6 +255,33 @@ namespace DepotTests.CRUDTests
                 .BeSameAs(secondMovieWithoutActors.Actors.First(a => a.ExternalId == firstActorResult.ExternalId));
         }
 
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        public async Task PopulateDetails_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit(int maxApiCalls)
+        {
+            // arrange
+            var firstMovie = new Movie() { Title = "My Cousin Vinny", ReleaseDate = 1992, ExternalId = 101, Genres = new List<Genre>() };
+            var secondMovie = new Movie() { Title = "Payback", ReleaseDate = 1999, ExternalId = 102, Genres = new List<Genre>() };
+            var thirdMovie = new Movie() { Title = "Office Space", ReleaseDate = 1999, ExternalId = 103, Genres = new List<Genre>() };
+
+            this._movieRepositoryMock
+                .Setup(m => m.GetMoviesWithoutActors())
+                .Returns(new[] { firstMovie, secondMovie, thirdMovie });
+
+            this._actorRepositoryMock.Setup(d => d.GetAll()).Returns(Enumerable.Empty<Actor>());
+
+            this._movieAPIClientMock
+                .Setup(m => m.GetMovieActorsAsync(It.IsAny<int>()))
+                .ReturnsAsync(new MovieActorResult[] { new MovieActorResult() });
+
+            // act
+            await this._movieDetailsFetcherActors.PopulateDetails(maxApiCalls);
+
+            // assert
+            this._movieAPIClientMock.Verify(m => m.GetMovieActorsAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));
+        }
+
     }
 
 }

--- a/DepotTests/CRUDTests/MovieDetailsFetcherDirectorsTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherDirectorsTests.cs
@@ -262,7 +262,7 @@ namespace DepotTests.CRUDTests
                 .ReturnsAsync(new MovieDirectorResult[] { new MovieDirectorResult() });
 
             // act
-            await this._movieDetailsFetcherDirectors.PopulateDetails();
+            await this._movieDetailsFetcherDirectors.PopulateDetails(maxApiCalls);
 
             // assert
             this._movieAPIClientMock.Verify(m => m.GetMovieDirectorsAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));

--- a/DepotTests/CRUDTests/MovieDetailsFetcherDirectorsTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherDirectorsTests.cs
@@ -239,5 +239,33 @@ namespace DepotTests.CRUDTests
                 .Should()
                 .BeSameAs(secondMovieWithoutDirectors.Directors.First(d => d.ExternalId == directorResult.ExternalId));
         }
+
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        public async Task PopulateDetails_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit(int maxApiCalls)
+        {
+            // arrange
+            var firstMovie = new Movie() { Title = "My Cousin Vinny", ReleaseDate = 1992, ExternalId = 101, Directors = new List<Director>() };
+            var secondMovie = new Movie() { Title = "Payback", ReleaseDate = 1999, ExternalId = 102, Directors = new List<Director>() };
+            var thirdMovie = new Movie() { Title = "Office Space", ReleaseDate = 1999, ExternalId = 103, Directors = new List<Director>() };
+
+            this._movieRepositoryMock
+                .Setup(m => m.GetMoviesWithoutDirectors())
+                .Returns(new[] { firstMovie, secondMovie,thirdMovie });
+
+            this._directorRepositoryMock.Setup(d => d.GetAll()).Returns(Enumerable.Empty<Director>());
+
+            this._movieAPIClientMock
+                .Setup(m => m.GetMovieDirectorsAsync(It.IsAny<int>()))
+                .ReturnsAsync(new MovieDirectorResult[] { new MovieDirectorResult() });
+
+            // act
+            await this._movieDetailsFetcherDirectors.PopulateDetails();
+
+            // assert
+            this._movieAPIClientMock.Verify(m => m.GetMovieDirectorsAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));
+        }
     }
 }

--- a/DepotTests/CRUDTests/MovieDetailsFetcherGenresTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherGenresTests.cs
@@ -189,7 +189,6 @@ namespace DepotTests.CRUDTests
             }
         }
 
-
         [Fact]
         public async Task PopulateDetails_WithMoviesMissingGenres_WithoutSuchGenresInRepo_WithSameGenreForAllMovies_ShouldBePopulatedWithTheSameGenreEntity()
         {
@@ -236,7 +235,6 @@ namespace DepotTests.CRUDTests
                 .Should()
                 .BeSameAs(secondMovieWithoutGenres.Genres.First(g => g.ExternalId == dramaGenreResult.ExternalId));
         }
-
 
         [Theory]
         [InlineData(2)]

--- a/DepotTests/CRUDTests/MovieDetailsFetcherGenresTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherGenresTests.cs
@@ -14,6 +14,7 @@ using MovieAPIClients.Interfaces;
 using FilmCRUD.Interfaces;
 using ConfigUtils.Interfaces;
 using System;
+using System.ComponentModel;
 
 namespace DepotTests.CRUDTests
 {
@@ -234,6 +235,34 @@ namespace DepotTests.CRUDTests
                 .First(g => g.ExternalId == dramaGenreResult.ExternalId)
                 .Should()
                 .BeSameAs(secondMovieWithoutGenres.Genres.First(g => g.ExternalId == dramaGenreResult.ExternalId));
+        }
+
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        public async Task PopulateDetails_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit(int maxApiCalls)
+        {
+            // arrange
+            var firstMovie = new Movie() { Title = "My Cousin Vinny", ReleaseDate = 1992, ExternalId = 101, Genres = new List<Genre>() };
+            var secondMovie = new Movie() { Title = "Payback", ReleaseDate = 1999, ExternalId = 102, Genres = new List<Genre>() };
+            var thirdMovie = new Movie() { Title = "Office Space", ReleaseDate = 1999, ExternalId = 103, Genres = new List<Genre>() };
+
+            this._movieRepositoryMock
+                .Setup(m => m.GetMoviesWithoutGenres())
+                .Returns(new[] { firstMovie, secondMovie, thirdMovie });
+
+            this._genreRepositoryMock.Setup(d => d.GetAll()).Returns(Enumerable.Empty<Genre>());
+
+            this._movieAPIClientMock
+                .Setup(m => m.GetMovieGenresAsync(It.IsAny<int>()))
+                .ReturnsAsync(new MovieGenreResult[] { new MovieGenreResult() });
+
+            // act
+            await this._movieDetailsFetcherGenres.PopulateDetails(maxApiCalls);
+
+            // assert
+            this._movieAPIClientMock.Verify(m => m.GetMovieGenresAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));
         }
 
     }

--- a/FilmCRUD/MovieDetailsFetcherAbstract.cs
+++ b/FilmCRUD/MovieDetailsFetcherAbstract.cs
@@ -57,7 +57,8 @@ namespace FilmCRUD
 
         public abstract IEnumerable<TDetailEntity> GetExistingDetailEntitiesInRepo();
 
-        // should be asynchronous and call one of the methods of IMovieAPIClient
+        // should be asynchronous and call one of the methods of IMovieAPIClient;
+        // each concrete subclass should invoke the relevant method, e.g., GetMovieActorsAsync, GetMovieGenresAsync etc...
         public abstract Task<IEnumerable<TAPIResult>> GetMovieDetailsFromApiAsync(int externalId);
 
         // TAPIResult to TDetailEntity conversion
@@ -65,7 +66,7 @@ namespace FilmCRUD
 
         public abstract void AddDetailsToMovieEntity(Movie movie, IEnumerable<TDetailEntity> details);
 
-        public async Task PopulateDetails()
+        public async Task PopulateDetails(int maxApiCalls = -1)
         {
             IEnumerable<Movie> moviesWithoutDetails = GetMoviesWithoutDetails();
 

--- a/FilmCRUD/MovieDetailsFetcherAbstract.cs
+++ b/FilmCRUD/MovieDetailsFetcherAbstract.cs
@@ -76,6 +76,13 @@ namespace FilmCRUD
 
             if (moviesWithoutDetailsCount == 0) return;
 
+            if (0 < maxApiCalls && maxApiCalls < moviesWithoutDetailsCount)
+            {
+                Log.Information("Limiting number of API calls to {CallLimit}", maxApiCalls);
+                moviesWithoutDetails = moviesWithoutDetails.Take(maxApiCalls).ToList();
+                moviesWithoutDetailsCount = maxApiCalls;
+            }
+
             AsyncPolicyWrap policyWrap = GetPolicyWrapFromConfigs(out TimeSpan initialDelay);
 
             // letting the token bucket fill for the current timespan...

--- a/FilmCRUD/MovieDetailsFetcherAbstract.cs
+++ b/FilmCRUD/MovieDetailsFetcherAbstract.cs
@@ -3,14 +3,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Net.Http;
 using System.Net;
-using System.IO;
 using System;
 using Polly;
 using Polly.RateLimit;
 using Polly.Wrap;
 using Serilog;
 using ConfigUtils.Interfaces;
-using FilmCRUD.Interfaces;
 using FilmDomain.Entities;
 using FilmDomain.Interfaces;
 using MovieAPIClients.Interfaces;
@@ -29,7 +27,6 @@ namespace FilmCRUD
         where TDetailEntity : IExternalEntity
         where TAPIResult : IExternalEntity
     {
-
         public static string DetailType { get => typeof(TDetailEntity).Name; }
 
         protected IUnitOfWork _unitOfWork { get; init; }
@@ -236,5 +233,4 @@ namespace FilmCRUD
         }
 
     }
-
 }

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -547,6 +547,7 @@ namespace FilmCRUD
                 Console.WriteLine(String.Join('\n', item.Value.OrderBy(s => s)));
             }
         }
+
     }
 
 }

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -436,21 +436,21 @@ namespace FilmCRUD
                 ILogger fetchingErrorsLogger = GetLoggerForFetchingErrors("logs/fetching_errors_genres_.txt");
                 var genresFetcher = new MovieDetailsFetcherGenres(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
                 Log.Information("Fetching genres for movies...");
-                await genresFetcher.PopulateDetails();
+                await genresFetcher.PopulateDetails(opts.MaxCalls ?? -1);
             }
             else if (opts.Actors)
             {
                 ILogger fetchingErrorsLogger = GetLoggerForFetchingErrors("logs/fetching_errors_actors_.txt");
                 var actorsFetcher = new MovieDetailsFetcherActors(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
                 Log.Information("Fetching actors for movies...");
-                await actorsFetcher.PopulateDetails();
+                await actorsFetcher.PopulateDetails(opts.MaxCalls ?? -1);
             }
             else if (opts.Directors)
             {
                 ILogger fetchingErrorsLogger = GetLoggerForFetchingErrors("logs/fetching_errors_directors_.txt");
                 var directorsFetcher = new MovieDetailsFetcherDirectors(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
                 Log.Information("Fetching directors for movies...");
-                await directorsFetcher.PopulateDetails();
+                await directorsFetcher.PopulateDetails(opts.MaxCalls ?? -1);
             }
             else if (opts.Keywords)
             {

--- a/FilmCRUD/Verbs/FetchOptions.cs
+++ b/FilmCRUD/Verbs/FetchOptions.cs
@@ -19,5 +19,8 @@ namespace FilmCRUD.Verbs
 
         [Option(SetName = "FetchIMDBIds", HelpText = "fetch imdb ids for movies")]
         public bool IMDBIds { get; set; }
+
+        [Option('m', "maxcalls", HelpText = "optional integer to limit the number of API calls")]
+        public int? MaxCalls { get; set; }
     }
 }


### PR DESCRIPTION
- [x] add new unittests to test new param `maxApiCalls` in method `MovieDetailsFetcherAbstract.PopulateDetails`:
    - [x] MovieDetailsFetcherDirectorsTests
    - [x] MovieDetailsFetcherGenresTests
    - [x] MovieDetailsFetcherActorsTests
- [x] implement new param usage `maxApiCalls` in in method `MovieDetailsFetcherAbstract.PopulateDetails`; include logs if used;
- [x] add new option to class `FetchOptions`: `link --search --max 25 ` or `link --search -m 25 `
- [x] amend `Program.HandleFetchOptionsto` use new option when calling methods from concrete subclasses of `MovieDetailsFetcherAbstract`