### PR TITLE
Fetch verb: add option to limit the number of API calls - simple

### DIFF
--- a/DepotTests/CRUDTests/MovieDetailsFetcherSimpleTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherSimpleTests.cs
@@ -140,6 +140,31 @@ namespace DepotTests.CRUDTests
             }
         }
 
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        public async Task PopulateMovieKeywordsAsync_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit(int maxApiCalls)
+        {
+            // arrange
+            var firstMovie = new Movie() { Title = "My Cousin Vinny", ReleaseDate = 1992, ExternalId = 101, Keywords = new List<string>() };
+            var secondMovie = new Movie() { Title = "Payback", ReleaseDate = 1999, ExternalId = 102, Keywords = new List<string>() };
+            var thirdMovie = new Movie() { Title = "Office Space", ReleaseDate = 1999, ExternalId = 103, Keywords = new List<string>() };
+
+            this._movieRepositoryMock
+                .Setup(m => m.GetMoviesWithoutKeywords())
+                .Returns(new[] { firstMovie, secondMovie, thirdMovie });
+
+            this._movieAPIClientMock
+                .Setup(m => m.GetMovieKeywordsAsync(It.IsAny<int>()))
+                .ReturnsAsync(new string[] { "dummy keyword" });
+
+            // act
+            await this._movieDetailsFetcherSimple.PopulateMovieKeywordsAsync(maxApiCalls);
+
+            // assert
+            this._movieAPIClientMock.Verify(m => m.GetMovieKeywordsAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));
+        }
+
         [Fact]
         public async Task PopulateMovieIMDBIdsAsync_WithoutMoviesMissingIMDBIds_ShouldNotCallApiClient()
         {
@@ -213,33 +238,6 @@ namespace DepotTests.CRUDTests
                 secondMovieWithoutIMDBId.IMDBId.Should().Be(secondMovieImdbId);
             }
         }
-
-
-        [Theory]
-        [InlineData(2)]
-        [InlineData(3)]
-        public async Task PopulateMovieKeywordsAsync_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit(int maxApiCalls)
-        {
-            // arrange
-            var firstMovie = new Movie() { Title = "My Cousin Vinny", ReleaseDate = 1992, ExternalId = 101, Keywords = new List<string>() };
-            var secondMovie = new Movie() { Title = "Payback", ReleaseDate = 1999, ExternalId = 102, Keywords = new List<string>() };
-            var thirdMovie = new Movie() { Title = "Office Space", ReleaseDate = 1999, ExternalId = 103, Keywords = new List<string>() };
-
-            this._movieRepositoryMock
-                .Setup(m => m.GetMoviesWithoutKeywords())
-                .Returns(new[] { firstMovie, secondMovie, thirdMovie });
-
-            this._movieAPIClientMock
-                .Setup(m => m.GetMovieKeywordsAsync(It.IsAny<int>()))
-                .ReturnsAsync(new string[] { "dummy keyword" });
-
-            // act
-            await this._movieDetailsFetcherSimple.PopulateMovieKeywordsAsync(maxApiCalls);
-
-            // assert
-            this._movieAPIClientMock.Verify(m => m.GetMovieKeywordsAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));
-        }
-
 
         [Theory]
         [InlineData(2)]

--- a/DepotTests/CRUDTests/MovieDetailsFetcherSimpleTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherSimpleTests.cs
@@ -66,7 +66,7 @@ namespace DepotTests.CRUDTests
         }
 
         [Fact]
-        public async Task PopulateMovieKeywords_WithoutMoviesMissingKeywords_ShouldNotCallApiClient()
+        public async Task PopulateMovieKeywordsAsync_WithoutMoviesMissingKeywords_ShouldNotCallApiClient()
         {
             // arrange
             this._movieRepositoryMock
@@ -74,14 +74,14 @@ namespace DepotTests.CRUDTests
                 .Returns(Enumerable.Empty<Movie>());
 
             // act
-            await this._movieDetailsFetcherSimple.PopulateMovieKeywords();
+            await this._movieDetailsFetcherSimple.PopulateMovieKeywordsAsync();
 
             // assert
             this._movieAPIClientMock.Verify(m => m.GetMovieKeywordsAsync(It.IsAny<int>()), Times.Never);
         }
 
         [Fact]
-        public async Task PopulateMovieKeywords_WithMoviesMissingKeywords_ShouldCallApiClient()
+        public async Task PopulateMovieKeywordsAsync_WithMoviesMissingKeywords_ShouldCallApiClient()
         {
             // arrange
             int firstExternalId = 101;
@@ -93,7 +93,7 @@ namespace DepotTests.CRUDTests
                 .Returns(new Movie[] { firstMovie, secondMovie });
 
             // act
-            await this._movieDetailsFetcherSimple.PopulateMovieKeywords();
+            await this._movieDetailsFetcherSimple.PopulateMovieKeywordsAsync();
 
             // assert
             this._movieAPIClientMock.Verify(
@@ -102,7 +102,7 @@ namespace DepotTests.CRUDTests
         }
 
         [Fact]
-        public async Task PopulateMovieKeywords_WithMoviesMissingKeywords_ShouldPopulateKeywordsCorrectly()
+        public async Task PopulateMovieKeywordsAsync_WithMoviesMissingKeywords_ShouldPopulateKeywordsCorrectly()
         {
             // arrange
             int firstExternalId = 101;
@@ -130,7 +130,7 @@ namespace DepotTests.CRUDTests
                 .ReturnsAsync(secondMovieKeywords);
 
             // act
-            await this._movieDetailsFetcherSimple.PopulateMovieKeywords();
+            await this._movieDetailsFetcherSimple.PopulateMovieKeywordsAsync();
 
             // assert
             using (new AssertionScope())
@@ -218,7 +218,7 @@ namespace DepotTests.CRUDTests
         [Theory]
         [InlineData(2)]
         [InlineData(3)]
-        public async Task PopulateMovieKeywords_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit(int maxApiCalls)
+        public async Task PopulateMovieKeywordsAsync_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit(int maxApiCalls)
         {
             // arrange
             var firstMovie = new Movie() { Title = "My Cousin Vinny", ReleaseDate = 1992, ExternalId = 101, Keywords = new List<string>() };
@@ -234,7 +234,7 @@ namespace DepotTests.CRUDTests
                 .ReturnsAsync(new string[] { "dummy keyword" });
 
             // act
-            await this._movieDetailsFetcherSimple.PopulateMovieKeywords(maxApiCalls);
+            await this._movieDetailsFetcherSimple.PopulateMovieKeywordsAsync(maxApiCalls);
 
             // assert
             this._movieAPIClientMock.Verify(m => m.GetMovieKeywordsAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));

--- a/DepotTests/CRUDTests/MovieDetailsFetcherSimpleTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherSimpleTests.cs
@@ -239,5 +239,31 @@ namespace DepotTests.CRUDTests
             // assert
             this._movieAPIClientMock.Verify(m => m.GetMovieKeywordsAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));
         }
+
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        public async Task PopulateMovieIMDBIds_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit(int maxApiCalls)
+        {
+            // arrange
+            var firstMovie = new Movie() { Title = "My Cousin Vinny", ReleaseDate = 1992, ExternalId = 101 };
+            var secondMovie = new Movie() { Title = "Payback", ReleaseDate = 1999, ExternalId = 102 };
+            var thirdMovie = new Movie() { Title = "Office Space", ReleaseDate = 1999, ExternalId = 103 };
+
+            this._movieRepositoryMock
+                .Setup(m => m.GetMoviesWithoutImdbId())
+                .Returns(new[] { firstMovie, secondMovie, thirdMovie });
+
+            this._movieAPIClientMock
+                .Setup(m => m.GetMovieIMDBIdAsync(It.IsAny<int>()))
+                .ReturnsAsync("tt00112233");
+
+            // act
+            await this._movieDetailsFetcherSimple.PopulateMovieIMDBIds();
+
+            // assert
+            this._movieAPIClientMock.Verify(m => m.GetMovieIMDBIdAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));
+        }
     }
 }

--- a/DepotTests/CRUDTests/MovieDetailsFetcherSimpleTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherSimpleTests.cs
@@ -12,6 +12,8 @@ using MovieAPIClients.Interfaces;
 using FilmCRUD.Interfaces;
 using ConfigUtils.Interfaces;
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace DepotTests.CRUDTests
 {
@@ -210,6 +212,32 @@ namespace DepotTests.CRUDTests
                 firstMovieWithoutIMDBId.IMDBId.Should().Be(firstMovieImdbId);
                 secondMovieWithoutIMDBId.IMDBId.Should().Be(secondMovieImdbId);
             }
+        }
+
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        public async Task PopulateMovieKeywords_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit(int maxApiCalls)
+        {
+            // arrange
+            var firstMovie = new Movie() { Title = "My Cousin Vinny", ReleaseDate = 1992, ExternalId = 101, Keywords = new List<string>() };
+            var secondMovie = new Movie() { Title = "Payback", ReleaseDate = 1999, ExternalId = 102, Keywords = new List<string>() };
+            var thirdMovie = new Movie() { Title = "Office Space", ReleaseDate = 1999, ExternalId = 103, Keywords = new List<string>() };
+
+            this._movieRepositoryMock
+                .Setup(m => m.GetMoviesWithoutKeywords())
+                .Returns(new[] { firstMovie, secondMovie, thirdMovie });
+
+            this._movieAPIClientMock
+                .Setup(m => m.GetMovieKeywordsAsync(It.IsAny<int>()))
+                .ReturnsAsync(new string[] { "dummy keyword" });
+
+            // act
+            await this._movieDetailsFetcherSimple.PopulateMovieKeywords(maxApiCalls);
+
+            // assert
+            this._movieAPIClientMock.Verify(m => m.GetMovieKeywordsAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));
         }
     }
 }

--- a/DepotTests/CRUDTests/MovieDetailsFetcherSimpleTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherSimpleTests.cs
@@ -258,7 +258,7 @@ namespace DepotTests.CRUDTests
                 .ReturnsAsync("tt00112233");
 
             // act
-            await this._movieDetailsFetcherSimple.PopulateMovieIMDBIdsAsync();
+            await this._movieDetailsFetcherSimple.PopulateMovieIMDBIdsAsync(maxApiCalls);
 
             // assert
             this._movieAPIClientMock.Verify(m => m.GetMovieIMDBIdAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));

--- a/DepotTests/CRUDTests/MovieDetailsFetcherSimpleTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherSimpleTests.cs
@@ -141,7 +141,7 @@ namespace DepotTests.CRUDTests
         }
 
         [Fact]
-        public async Task PopulateMovieIMDBIds_WithoutMoviesMissingIMDBIds_ShouldNotCallApiClient()
+        public async Task PopulateMovieIMDBIdsAsync_WithoutMoviesMissingIMDBIds_ShouldNotCallApiClient()
         {
             // arrange
             this._movieRepositoryMock
@@ -149,14 +149,14 @@ namespace DepotTests.CRUDTests
                 .Returns(Enumerable.Empty<Movie>());
 
             // act
-            await this._movieDetailsFetcherSimple.PopulateMovieIMDBIds();
+            await this._movieDetailsFetcherSimple.PopulateMovieIMDBIdsAsync();
 
             // assert
             this._movieAPIClientMock.Verify(m => m.GetMovieIMDBIdAsync(It.IsAny<int>()), Times.Never);
         }
 
         [Fact]
-        public async Task PopulateMovieIMDBIds_WithMoviesMissingIMDBIds_ShouldCallApiClient()
+        public async Task PopulateMovieIMDBIdsAsync_WithMoviesMissingIMDBIds_ShouldCallApiClient()
         {
             // arrange
             int firstExternalId = 101;
@@ -168,7 +168,7 @@ namespace DepotTests.CRUDTests
                 .Returns(new Movie[] { firstMovie, secondMovie });
 
             // act
-            await this._movieDetailsFetcherSimple.PopulateMovieIMDBIds();
+            await this._movieDetailsFetcherSimple.PopulateMovieIMDBIdsAsync();
 
             // assert
             this._movieAPIClientMock.Verify(
@@ -177,7 +177,7 @@ namespace DepotTests.CRUDTests
         }
 
         [Fact]
-        public async Task PopulateMovieIMDBIds_WithMoviesMissingIMDBIds_ShouldPopulateIMDBIdsCorrectly()
+        public async Task PopulateMovieIMDBIdsAsync_WithMoviesMissingIMDBIds_ShouldPopulateIMDBIdsCorrectly()
         {
             // arrange
             int firstExternalId = 101;
@@ -204,7 +204,7 @@ namespace DepotTests.CRUDTests
                 .ReturnsAsync(secondMovieImdbId);
 
             // act
-            await this._movieDetailsFetcherSimple.PopulateMovieIMDBIds();
+            await this._movieDetailsFetcherSimple.PopulateMovieIMDBIdsAsync();
 
             // assert
             using (new AssertionScope())
@@ -244,7 +244,7 @@ namespace DepotTests.CRUDTests
         [Theory]
         [InlineData(2)]
         [InlineData(3)]
-        public async Task PopulateMovieIMDBIds_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit(int maxApiCalls)
+        public async Task PopulateMovieIMDBIdsAsync_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit(int maxApiCalls)
         {
             // arrange
             var firstMovie = new Movie() { Title = "My Cousin Vinny", ReleaseDate = 1992, ExternalId = 101 };
@@ -260,7 +260,7 @@ namespace DepotTests.CRUDTests
                 .ReturnsAsync("tt00112233");
 
             // act
-            await this._movieDetailsFetcherSimple.PopulateMovieIMDBIds();
+            await this._movieDetailsFetcherSimple.PopulateMovieIMDBIdsAsync();
 
             // assert
             this._movieAPIClientMock.Verify(m => m.GetMovieIMDBIdAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));

--- a/FilmCRUD/MovieDetailsFetcherSimple.cs
+++ b/FilmCRUD/MovieDetailsFetcherSimple.cs
@@ -62,7 +62,7 @@ namespace FilmCRUD
             await PopulateDetailsSimpleAsync<IEnumerable<string>>(moviesWithoutDetailsGetterFunc, detailsGetterFunc, detailsPopulatorAction, "Keywords");
         }
 
-        public async Task PopulateMovieIMDBIds()
+        public async Task PopulateMovieIMDBIdsAsync()
         {
             Func<IEnumerable<Movie>> moviesWithoutDetailsGetterFunc = this._unitOfWork.Movies.GetMoviesWithoutImdbId;
 

--- a/FilmCRUD/MovieDetailsFetcherSimple.cs
+++ b/FilmCRUD/MovieDetailsFetcherSimple.cs
@@ -59,7 +59,7 @@ namespace FilmCRUD
 
             Action<Movie, IEnumerable<string>> detailsPopulatorAction = (movie, kwds) => movie.Keywords = kwds.ToList();
 
-            await PopulateDetailsSimple<IEnumerable<string>>(moviesWithoutDetailsGetterFunc, detailsGetterFunc, detailsPopulatorAction, "Keywords");
+            await PopulateDetailsSimpleAsync<IEnumerable<string>>(moviesWithoutDetailsGetterFunc, detailsGetterFunc, detailsPopulatorAction, "Keywords");
         }
 
         public async Task PopulateMovieIMDBIds()
@@ -70,10 +70,10 @@ namespace FilmCRUD
 
             Action<Movie, string> detailsPopulatorAction = (movie, imdbId) => movie.IMDBId = imdbId;
 
-            await PopulateDetailsSimple<string>(moviesWithoutDetailsGetterFunc, detailsGetterFunc, detailsPopulatorAction, "IMDBId");
+            await PopulateDetailsSimpleAsync<string>(moviesWithoutDetailsGetterFunc, detailsGetterFunc, detailsPopulatorAction, "IMDBId");
         }
 
-        private async Task PopulateDetailsSimple<TDetail>(
+        private async Task PopulateDetailsSimpleAsync<TDetail>(
             Func<IEnumerable<Movie>> moviesWithoutDetailsGetterFunc,
             Func<int, Task<TDetail>> detailsGetterFunc,
             Action<Movie, TDetail> detailsPopulatorAction,

--- a/FilmCRUD/MovieDetailsFetcherSimple.cs
+++ b/FilmCRUD/MovieDetailsFetcherSimple.cs
@@ -201,5 +201,4 @@ namespace FilmCRUD
         }
 
     }
-
 }

--- a/FilmCRUD/MovieDetailsFetcherSimple.cs
+++ b/FilmCRUD/MovieDetailsFetcherSimple.cs
@@ -51,7 +51,7 @@ namespace FilmCRUD
             IMovieAPIClient movieAPIClient,
             ILogger fetchingErrorsLogger) : this(unitOfWork, appSettingsManager, movieAPIClient) => this._fetchingErrorsLogger = fetchingErrorsLogger;
 
-        public async Task PopulateMovieKeywords()
+        public async Task PopulateMovieKeywords(int maxApiCalls = -1)
         {
             Func<IEnumerable<Movie>> moviesWithoutDetailsGetterFunc = this._unitOfWork.Movies.GetMoviesWithoutKeywords;
 

--- a/FilmCRUD/MovieDetailsFetcherSimple.cs
+++ b/FilmCRUD/MovieDetailsFetcherSimple.cs
@@ -51,7 +51,7 @@ namespace FilmCRUD
             IMovieAPIClient movieAPIClient,
             ILogger fetchingErrorsLogger) : this(unitOfWork, appSettingsManager, movieAPIClient) => this._fetchingErrorsLogger = fetchingErrorsLogger;
 
-        public async Task PopulateMovieKeywords(int maxApiCalls = -1)
+        public async Task PopulateMovieKeywordsAsync(int maxApiCalls = -1)
         {
             Func<IEnumerable<Movie>> moviesWithoutDetailsGetterFunc = this._unitOfWork.Movies.GetMoviesWithoutKeywords;
 

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -457,7 +457,7 @@ namespace FilmCRUD
                 ILogger fetchingErrorsLogger = GetLoggerForFetchingErrors("logs/fetching_errors_keywords_.txt");
                 var keywordsFetcher = new MovieDetailsFetcherSimple(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
                 Log.Information("Fetching keywords for movies...");
-                await keywordsFetcher.PopulateMovieKeywords();
+                await keywordsFetcher.PopulateMovieKeywordsAsync();
             }
             else if (opts.IMDBIds)
             {

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -457,14 +457,14 @@ namespace FilmCRUD
                 ILogger fetchingErrorsLogger = GetLoggerForFetchingErrors("logs/fetching_errors_keywords_.txt");
                 var keywordsFetcher = new MovieDetailsFetcherSimple(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
                 Log.Information("Fetching keywords for movies...");
-                await keywordsFetcher.PopulateMovieKeywordsAsync();
+                await keywordsFetcher.PopulateMovieKeywordsAsync(opts.MaxCalls ?? -1);
             }
             else if (opts.IMDBIds)
             {
                 ILogger fetchingErrorsLogger = GetLoggerForFetchingErrors("logs/fetching_errors_imdbids_.txt");
                 var IMDBIdFetcher = new MovieDetailsFetcherSimple(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
                 Log.Information("Fetching IMDB ids for movies...");
-                await IMDBIdFetcher.PopulateMovieIMDBIdsAsync();
+                await IMDBIdFetcher.PopulateMovieIMDBIdsAsync(opts.MaxCalls ?? -1);
             }
             else
             {

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -464,7 +464,7 @@ namespace FilmCRUD
                 ILogger fetchingErrorsLogger = GetLoggerForFetchingErrors("logs/fetching_errors_imdbids_.txt");
                 var IMDBIdFetcher = new MovieDetailsFetcherSimple(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
                 Log.Information("Fetching IMDB ids for movies...");
-                await IMDBIdFetcher.PopulateMovieIMDBIds();
+                await IMDBIdFetcher.PopulateMovieIMDBIdsAsync();
             }
             else
             {


### PR DESCRIPTION
- [x] add new unittests to test new param `maxApiCalls` in method `MovieDetailsFetcherSimple.PopulateMovieKeywords`
- [x] implement new param usage `maxApiCalls` in in method MovieDetailsFetcherSimple.PopulateMovieKeywords; include logs if used;
- [x] add new unittests to test new param `maxApiCalls` in method `MovieDetailsFetcherSimple.PopulateMovieIMDBIds`
- [x] implement new param usage `maxApiCalls` in in method MovieDetailsFetcherSimple.PopulateMovieIMDBIds; include logs if used;
- [x] amend `Program.HandleFetchOptions` to use new option 