### PR TITLE
Scanrips verb: add search option

### DIFF
--- a/DepotTests/CRUDTests/ScanRipsManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanRipsManagerTests.cs
@@ -336,11 +336,11 @@ namespace DepotTests.CRUDTests
                 .Returns(visit.MovieRips);
 
             // act
-            IEnumerable<string> actualSearchResult = this._scanRipsManager.SearchFromFileNameTokens(visit, fileNameSearch);
+            IEnumerable<MovieRip> actualSearchResult = this._scanRipsManager.SearchFromFileNameTokens(visit, fileNameSearch);
 
             // assert
             actualSearchResult.Should().BeEquivalentTo(
-                visit.MovieRips.Where(mr => idsForExpectedResult.Contains(mr.Id)).Select(mr => mr.FileName));
+                visit.MovieRips.Where(mr => idsForExpectedResult.Contains(mr.Id)));
         }
     }
 }

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -548,5 +548,4 @@ namespace FilmCRUD
         }
 
     }
-
 }

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -231,6 +231,20 @@ namespace FilmCRUD
                 Console.WriteLine("ScanRips: last visit difference \n");
                 PrintVisitDiff(scanRipsManager.GetLastVisitDiff());
             }
+            else if (opts.Search != null)
+            {
+                string toSearch = opts.Search;
+                Console.WriteLine($"Search by filename tokens: \"{toSearch}\" \n");
+                IEnumerable<MovieRip> searchResult = scanRipsManager.SearchFromFileNameTokens(visit, toSearch);
+                if (!searchResult.Any())
+                {
+                    Console.WriteLine("No matches...");
+                }
+                else
+                {
+                    searchResult.ToList().ForEach(mr => Console.WriteLine("-------------" + '\n' + mr.PrettyFormat()));
+                }
+            }
             else
             {
                 Console.WriteLine("No action requested...");

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -234,6 +234,7 @@ namespace FilmCRUD
             else if (opts.Search != null)
             {
                 string toSearch = opts.Search;
+                Console.WriteLine($"Visit: {visit.VisitDateTime.ToString(printDateFormat)}");
                 Console.WriteLine($"Search by filename tokens: \"{toSearch}\" \n");
                 IEnumerable<MovieRip> searchResult = scanRipsManager.SearchFromFileNameTokens(visit, toSearch);
                 if (!searchResult.Any())

--- a/FilmCRUD/ScanRipsManager.cs
+++ b/FilmCRUD/ScanRipsManager.cs
@@ -83,17 +83,19 @@ namespace FilmCRUD
             };
         }
 
-        public IEnumerable<string> SearchFromFileNameTokens(MovieWarehouseVisit visit, string fileNameTokens)
+        public IEnumerable<MovieRip> SearchFromFileNameTokens(MovieWarehouseVisit visit, string fileNameTokens)
         {
             // ToList forces execution
-            IEnumerable<string> ripsFilenamesInVisit = this.UnitOfWork.MovieRips.GetAllRipsInVisit(visit).GetFileNames().ToList();
+            IEnumerable<MovieRip> ripsInVisit = this.UnitOfWork.MovieRips.GetAllRipsInVisit(visit).ToList();
             
             var tokensToSearch = fileNameTokens.GetStringTokensWithoutPunctuation(removeDiacritics: true);
-            Dictionary<string, IEnumerable<string>> ripFileNameTokens = ripsFilenamesInVisit.ToDictionary(
-                s => s,
-                s => s.GetStringTokensWithoutPunctuation(removeDiacritics: true)
+
+            // maps each MovieRip entity id to the tokens its filename has in common with the search param
+            Dictionary<int, IEnumerable<string>> ripFileNameTokensIntersection = ripsInVisit.ToDictionary(
+                mr => mr.Id,
+                mr => mr.FileName.GetStringTokensWithoutPunctuation(removeDiacritics: true).Intersect(tokensToSearch)
             );
-            return ripFileNameTokens.Where(kvp => kvp.Value.Intersect(tokensToSearch).Any()).Select(kvp => kvp.Key);
+            return ripsInVisit.Where(mr => ripFileNameTokensIntersection[mr.Id].Any());
         }
 
     }

--- a/FilmCRUD/ScanRipsManager.cs
+++ b/FilmCRUD/ScanRipsManager.cs
@@ -83,5 +83,18 @@ namespace FilmCRUD
             };
         }
 
+        public IEnumerable<string> SearchFromFileNameTokens(MovieWarehouseVisit visit, string fileNameTokens)
+        {
+            // ToList forces execution
+            IEnumerable<string> ripsFilenamesInVisit = this.UnitOfWork.MovieRips.GetAllRipsInVisit(visit).GetFileNames().ToList();
+            
+            var tokensToSearch = fileNameTokens.GetStringTokensWithoutPunctuation(removeDiacritics: true);
+            Dictionary<string, IEnumerable<string>> ripFileNameTokens = ripsFilenamesInVisit.ToDictionary(
+                s => s,
+                s => s.GetStringTokensWithoutPunctuation(removeDiacritics: true)
+            );
+            return ripFileNameTokens.Where(kvp => kvp.Value.Intersect(tokensToSearch).Any()).Select(kvp => kvp.Key);
+        }
+
     }
 }

--- a/FilmCRUD/Verbs/ScanRipsOptions.cs
+++ b/FilmCRUD/Verbs/ScanRipsOptions.cs
@@ -26,6 +26,9 @@ namespace FilmCRUD.Verbs
             HelpText = "movie rip difference between two visits with dates YYYYMMDD: added and removed movie rips; example: 20100101:20100102")]
         public IEnumerable<string> VisitDiff { get; set; }
 
+        [Option(SetName = "SearchOption", HelpText = "search movie rip filenames by tokens; examples: \"the.wicker.man.1973\", \"wicker man 1973\"")]
+        public string Search { get; set; }
+
         [Option('l', "listvisits", SetName = "ListVisitsOption", HelpText = "helper; list dates for all visits")]
         public bool ListVisits { get; set; }
 

--- a/FilmDomain/Extensions/EntityExtensions.cs
+++ b/FilmDomain/Extensions/EntityExtensions.cs
@@ -128,5 +128,22 @@ namespace FilmDomain.Extensions
             string _kwds = movie.Keywords == null ? string.Empty : string.Join(", ", movie.Keywords);
             return string.Join('\n', new string[] {movie.ToString(), _genres, $"Directors: {_directors}", $"IMDB id: {movie.IMDBId}", $"Keywords: {_kwds}" });
         }
+
+        public static string PrettyFormat(this MovieRip movieRip)
+        {
+            string _id = $"Id: {movieRip.Id}";
+            string _filename = $"Filename: {movieRip.FileName}";
+            string _parsedTitle = $"ParsedTitle: {movieRip.ParsedTitle}";
+            string _parsedReleaseDate = $"ParsedReleaseDate: {movieRip.ParsedReleaseDate}";
+            string _parsedRipQuality = $"ParsedRipQuality: {movieRip.ParsedRipQuality}";
+            string _parsedRipInfo = $"ParsedRipInfo: {movieRip.ParsedRipInfo}";
+            string _parsedRipGroup = $"ParsedRipGroup: {movieRip.ParsedRipGroup}";
+            string _linkedMovie = $"Linked movie: {movieRip.Movie}";
+            string _warehouseVisits = "Warehouse visits: " + string.Join('\t', movieRip.MovieWarehouseVisits.Select(v => $"{v.VisitDateTime:MMMM dd yyyy}"));
+            return string.Join('\n', new string[] {
+                _id, _filename, _parsedTitle, _parsedReleaseDate,
+                _parsedRipQuality, _parsedRipInfo, _parsedRipGroup,
+                _linkedMovie, _warehouseVisits });
+        }
     }
 }

--- a/FilmDomain/Extensions/EntityExtensions.cs
+++ b/FilmDomain/Extensions/EntityExtensions.cs
@@ -139,11 +139,10 @@ namespace FilmDomain.Extensions
             string _parsedRipInfo = $"ParsedRipInfo: {movieRip.ParsedRipInfo}";
             string _parsedRipGroup = $"ParsedRipGroup: {movieRip.ParsedRipGroup}";
             string _linkedMovie = $"Linked movie: {movieRip.Movie}";
-            string _warehouseVisits = "Warehouse visits: " + string.Join('\t', movieRip.MovieWarehouseVisits.Select(v => $"{v.VisitDateTime:MMMM dd yyyy}"));
             return string.Join('\n', new string[] {
                 _id, _filename, _parsedTitle, _parsedReleaseDate,
                 _parsedRipQuality, _parsedRipInfo, _parsedRipGroup,
-                _linkedMovie, _warehouseVisits });
+                _linkedMovie });
         }
     }
 }


### PR DESCRIPTION
examples: `scanrips --search "dumb and dumber"` , `scanrips --search "dumb and dumber 1994"` , `scanrips --search "dumb and dumber (1994)"`

- [x] new method `ScanRipsManager.SearchFromFileNameTokens`
- [x] unittests for new method `ScanRipsManager.SearchFromFileNameTokens`
- [x] new property in `ScanRipsOptions`: `public string Search { get; set; }`
- [x] amend `Program.HandleScanRipsOptions`