### PR TITLE
Rename FilmDomain entity to CastMember

### DIFF
--- a/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
@@ -33,7 +33,7 @@ namespace DepotTests.CRUDTests
 
         private readonly Mock<IMovieAPIClient> _movieAPIClientMock;
 
-        private readonly MovieDetailsFetcherActors _movieDetailsFetcherActors;
+        private readonly MovieDetailsFetcherCastMembers _movieDetailsFetcherActors;
 
         public MovieDetailsFetcherActorsTests()
         {
@@ -65,7 +65,7 @@ namespace DepotTests.CRUDTests
 
             this._movieAPIClientMock = new Mock<IMovieAPIClient>();
 
-            this._movieDetailsFetcherActors = new MovieDetailsFetcherActors(
+            this._movieDetailsFetcherActors = new MovieDetailsFetcherCastMembers(
                 this._unitOfWorkMock.Object,
                 this._appSettingsManagerMock.Object,
                 this._movieAPIClientMock.Object);

--- a/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
@@ -94,7 +94,7 @@ namespace DepotTests.CRUDTests
                 Title = "the fly",
                 ReleaseDate = 1986,
                 ExternalId = externalId,
-                Actors = new List<CastMember>()
+                CastMembers = new List<CastMember>()
             };
             this._actorRepositoryMock
                 .Setup(a => a.GetAll())
@@ -127,14 +127,14 @@ namespace DepotTests.CRUDTests
                 Title = "i'm still here",
                 ReleaseDate = 2010,
                 ExternalId = firstExternalId,
-                Actors = new List<CastMember>()
+                CastMembers = new List<CastMember>()
             };
             var secondMovieWithoutActors = new Movie()
             {
                 Title = "joker",
                 ReleaseDate = 2019,
                 ExternalId = secondExternalId,
-                Actors = new List<CastMember>()
+                CastMembers = new List<CastMember>()
             };
             this._actorRepositoryMock
                 .Setup(a => a.GetAll())
@@ -152,8 +152,8 @@ namespace DepotTests.CRUDTests
             // assert
             using (new AssertionScope())
             {
-                firstMovieWithoutActors.Actors.FirstOrDefault().Should().BeSameAs(actor);
-                secondMovieWithoutActors.Actors.FirstOrDefault().Should().BeSameAs(actor);
+                firstMovieWithoutActors.CastMembers.FirstOrDefault().Should().BeSameAs(actor);
+                secondMovieWithoutActors.CastMembers.FirstOrDefault().Should().BeSameAs(actor);
             }
         }
 
@@ -174,14 +174,14 @@ namespace DepotTests.CRUDTests
                 Title = "i'm still here",
                 ReleaseDate = 2010,
                 ExternalId = firstExternalId,
-                Actors = new List<CastMember>()
+                CastMembers = new List<CastMember>()
             };
             var secondMovieWithoutActors = new Movie()
             {
                 Title = "the village",
                 ReleaseDate = 2004,
                 ExternalId = secondExternalId,
-                Actors = new List<CastMember>()
+                CastMembers = new List<CastMember>()
             };
 
             this._actorRepositoryMock
@@ -203,8 +203,8 @@ namespace DepotTests.CRUDTests
             // assert
             using (new AssertionScope())
             {
-                firstMovieWithoutActors.Actors.Should().BeEquivalentTo(new List<CastMember>() { firstActor });
-                secondMovieWithoutActors.Actors.Should().BeEquivalentTo(new List<CastMember>() { firstActor, secondActor });
+                firstMovieWithoutActors.CastMembers.Should().BeEquivalentTo(new List<CastMember>() { firstActor });
+                secondMovieWithoutActors.CastMembers.Should().BeEquivalentTo(new List<CastMember>() { firstActor, secondActor });
             }
         }
 
@@ -222,14 +222,14 @@ namespace DepotTests.CRUDTests
                 Title = "i'm still here",
                 ReleaseDate = 2010,
                 ExternalId = firstExternalId,
-                Actors = new List<CastMember>()
+                CastMembers = new List<CastMember>()
             };
             var secondMovieWithoutActors = new Movie()
             {
                 Title = "the village",
                 ReleaseDate = 2004,
                 ExternalId = secondExternalId,
-                Actors = new List<CastMember>()
+                CastMembers = new List<CastMember>()
             };
 
             this._actorRepositoryMock
@@ -249,10 +249,10 @@ namespace DepotTests.CRUDTests
             await this._movieDetailsFetcherActors.PopulateDetails();
 
             // assert
-            firstMovieWithoutActors.Actors
+            firstMovieWithoutActors.CastMembers
                 .First(a => a.ExternalId == firstActorResult.ExternalId)
                 .Should()
-                .BeSameAs(secondMovieWithoutActors.Actors.First(a => a.ExternalId == firstActorResult.ExternalId));
+                .BeSameAs(secondMovieWithoutActors.CastMembers.First(a => a.ExternalId == firstActorResult.ExternalId));
         }
 
         [Theory]
@@ -261,9 +261,9 @@ namespace DepotTests.CRUDTests
         public async Task PopulateDetails_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit(int maxApiCalls)
         {
             // arrange
-            var firstMovie = new Movie() { Title = "My Cousin Vinny", ReleaseDate = 1992, ExternalId = 101, Actors = new List<CastMember>() };
-            var secondMovie = new Movie() { Title = "Payback", ReleaseDate = 1999, ExternalId = 102, Actors = new List<CastMember>() };
-            var thirdMovie = new Movie() { Title = "Office Space", ReleaseDate = 1999, ExternalId = 103, Actors = new List<CastMember>() };
+            var firstMovie = new Movie() { Title = "My Cousin Vinny", ReleaseDate = 1992, ExternalId = 101, CastMembers = new List<CastMember>() };
+            var secondMovie = new Movie() { Title = "Payback", ReleaseDate = 1999, ExternalId = 102, CastMembers = new List<CastMember>() };
+            var thirdMovie = new Movie() { Title = "Office Space", ReleaseDate = 1999, ExternalId = 103, CastMembers = new List<CastMember>() };
 
             this._movieRepositoryMock
                 .Setup(m => m.GetMoviesWithoutActors())

--- a/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
@@ -104,7 +104,7 @@ namespace DepotTests.CRUDTests
                 .Returns(new Movie[] { movieWithoutActors });
             this._movieAPIClientMock
                 .Setup(m => m.GetMovieActorsAsync(It.IsAny<int>()))
-                .ReturnsAsync(Enumerable.Empty<MovieActorResult>());
+                .ReturnsAsync(Enumerable.Empty<MovieCastMemberResult>());
 
             // act
             await this._movieDetailsFetcherActors.PopulateDetails();
@@ -117,7 +117,7 @@ namespace DepotTests.CRUDTests
         public async Task PopulateDetails_WithMovieMissingActors_WithExistingActorResultInRepo_ShouldBePopulatedWithExistingActor()
         {
             // arrange
-            var actorResult = new MovieActorResult() { Name = "joaquin phoenix", ExternalId = 201 };
+            var actorResult = new MovieCastMemberResult() { Name = "joaquin phoenix", ExternalId = 201 };
             var actor = (CastMember)actorResult;
 
             int firstExternalId = 101;
@@ -144,7 +144,7 @@ namespace DepotTests.CRUDTests
                 .Returns(new Movie[] { firstMovieWithoutActors, secondMovieWithoutActors });
             this._movieAPIClientMock
                 .Setup(cl => cl.GetMovieActorsAsync(It.Is<int>(i => i == firstExternalId | i == secondExternalId)))
-                .ReturnsAsync(new MovieActorResult[] { actorResult });
+                .ReturnsAsync(new MovieCastMemberResult[] { actorResult });
 
             // act
             await this._movieDetailsFetcherActors.PopulateDetails();
@@ -161,10 +161,10 @@ namespace DepotTests.CRUDTests
         public async Task PopulateDetails_WithMovieMissingActors_WithoutSuchActorsInRepo_ShouldBePopulatedWithNewActors()
         {
             // arrange
-            var firstActorResult = new MovieActorResult() { Name = "joaquin phoenix", ExternalId = 201 };
+            var firstActorResult = new MovieCastMemberResult() { Name = "joaquin phoenix", ExternalId = 201 };
             var firstActor = (CastMember)firstActorResult;
 
-            var secondActorResult = new MovieActorResult() { Name = "adrien brody", ExternalId = 202 };
+            var secondActorResult = new MovieCastMemberResult() { Name = "adrien brody", ExternalId = 202 };
             var secondActor = (CastMember)secondActorResult;
 
             int firstExternalId = 101;
@@ -192,10 +192,10 @@ namespace DepotTests.CRUDTests
                 .Returns(new Movie[] { firstMovieWithoutActors, secondMovieWithoutActors });
             this._movieAPIClientMock
                 .Setup(cl => cl.GetMovieActorsAsync(firstExternalId))
-                .ReturnsAsync(new MovieActorResult[] { firstActorResult });
+                .ReturnsAsync(new MovieCastMemberResult[] { firstActorResult });
             this._movieAPIClientMock
                 .Setup(cl => cl.GetMovieActorsAsync(secondExternalId))
-                .ReturnsAsync(new MovieActorResult[] { firstActorResult, secondActorResult });
+                .ReturnsAsync(new MovieCastMemberResult[] { firstActorResult, secondActorResult });
 
             // act
             await this._movieDetailsFetcherActors.PopulateDetails();
@@ -212,8 +212,8 @@ namespace DepotTests.CRUDTests
         public async Task PopulateDetails_WithMoviesMissingActors_WithoutSuchActorsInRepo_WithSameActorForAllMovies_ShouldBePopulatedWithTheSameActorEntity()
         {
             // arrange
-            var firstActorResult = new MovieActorResult() { Name = "joaquin phoenix", ExternalId = 201 };
-            var secondActorResult = new MovieActorResult() { Name = "adrien brody", ExternalId = 202 };
+            var firstActorResult = new MovieCastMemberResult() { Name = "joaquin phoenix", ExternalId = 201 };
+            var secondActorResult = new MovieCastMemberResult() { Name = "adrien brody", ExternalId = 202 };
 
             int firstExternalId = 101;
             int secondExternalId = 102;
@@ -240,10 +240,10 @@ namespace DepotTests.CRUDTests
                 .Returns(new Movie[] { firstMovieWithoutActors, secondMovieWithoutActors });
             this._movieAPIClientMock
                 .Setup(cl => cl.GetMovieActorsAsync(firstExternalId))
-                .ReturnsAsync(new MovieActorResult[] { firstActorResult });
+                .ReturnsAsync(new MovieCastMemberResult[] { firstActorResult });
             this._movieAPIClientMock
                 .Setup(cl => cl.GetMovieActorsAsync(secondExternalId))
-                .ReturnsAsync(new MovieActorResult[] { firstActorResult, secondActorResult });
+                .ReturnsAsync(new MovieCastMemberResult[] { firstActorResult, secondActorResult });
 
             // act
             await this._movieDetailsFetcherActors.PopulateDetails();
@@ -273,7 +273,7 @@ namespace DepotTests.CRUDTests
 
             this._movieAPIClientMock
                 .Setup(m => m.GetMovieActorsAsync(It.IsAny<int>()))
-                .ReturnsAsync(new MovieActorResult[] { new MovieActorResult() });
+                .ReturnsAsync(new MovieCastMemberResult[] { new MovieCastMemberResult() });
 
             // act
             await this._movieDetailsFetcherActors.PopulateDetails(maxApiCalls);

--- a/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
@@ -94,11 +94,11 @@ namespace DepotTests.CRUDTests
                 Title = "the fly",
                 ReleaseDate = 1986,
                 ExternalId = externalId,
-                Actors = new List<Actor>()
+                Actors = new List<CastMember>()
             };
             this._actorRepositoryMock
                 .Setup(a => a.GetAll())
-                .Returns(new List<Actor>());
+                .Returns(new List<CastMember>());
             this._movieRepositoryMock
                 .Setup(m => m.GetMoviesWithoutActors())
                 .Returns(new Movie[] { movieWithoutActors });
@@ -118,7 +118,7 @@ namespace DepotTests.CRUDTests
         {
             // arrange
             var actorResult = new MovieActorResult() { Name = "joaquin phoenix", ExternalId = 201 };
-            var actor = (Actor)actorResult;
+            var actor = (CastMember)actorResult;
 
             int firstExternalId = 101;
             int secondExternalId = 102;
@@ -127,18 +127,18 @@ namespace DepotTests.CRUDTests
                 Title = "i'm still here",
                 ReleaseDate = 2010,
                 ExternalId = firstExternalId,
-                Actors = new List<Actor>()
+                Actors = new List<CastMember>()
             };
             var secondMovieWithoutActors = new Movie()
             {
                 Title = "joker",
                 ReleaseDate = 2019,
                 ExternalId = secondExternalId,
-                Actors = new List<Actor>()
+                Actors = new List<CastMember>()
             };
             this._actorRepositoryMock
                 .Setup(a => a.GetAll())
-                .Returns(new List<Actor>() { actor });
+                .Returns(new List<CastMember>() { actor });
             this._movieRepositoryMock
                 .Setup(m => m.GetMoviesWithoutActors())
                 .Returns(new Movie[] { firstMovieWithoutActors, secondMovieWithoutActors });
@@ -162,10 +162,10 @@ namespace DepotTests.CRUDTests
         {
             // arrange
             var firstActorResult = new MovieActorResult() { Name = "joaquin phoenix", ExternalId = 201 };
-            var firstActor = (Actor)firstActorResult;
+            var firstActor = (CastMember)firstActorResult;
 
             var secondActorResult = new MovieActorResult() { Name = "adrien brody", ExternalId = 202 };
-            var secondActor = (Actor)secondActorResult;
+            var secondActor = (CastMember)secondActorResult;
 
             int firstExternalId = 101;
             int secondExternalId = 102;
@@ -174,19 +174,19 @@ namespace DepotTests.CRUDTests
                 Title = "i'm still here",
                 ReleaseDate = 2010,
                 ExternalId = firstExternalId,
-                Actors = new List<Actor>()
+                Actors = new List<CastMember>()
             };
             var secondMovieWithoutActors = new Movie()
             {
                 Title = "the village",
                 ReleaseDate = 2004,
                 ExternalId = secondExternalId,
-                Actors = new List<Actor>()
+                Actors = new List<CastMember>()
             };
 
             this._actorRepositoryMock
                 .Setup(a => a.GetAll())
-                .Returns(Enumerable.Empty<Actor>());
+                .Returns(Enumerable.Empty<CastMember>());
             this._movieRepositoryMock
                 .Setup(m => m.GetMoviesWithoutActors())
                 .Returns(new Movie[] { firstMovieWithoutActors, secondMovieWithoutActors });
@@ -203,8 +203,8 @@ namespace DepotTests.CRUDTests
             // assert
             using (new AssertionScope())
             {
-                firstMovieWithoutActors.Actors.Should().BeEquivalentTo(new List<Actor>() { firstActor });
-                secondMovieWithoutActors.Actors.Should().BeEquivalentTo(new List<Actor>() { firstActor, secondActor });
+                firstMovieWithoutActors.Actors.Should().BeEquivalentTo(new List<CastMember>() { firstActor });
+                secondMovieWithoutActors.Actors.Should().BeEquivalentTo(new List<CastMember>() { firstActor, secondActor });
             }
         }
 
@@ -222,19 +222,19 @@ namespace DepotTests.CRUDTests
                 Title = "i'm still here",
                 ReleaseDate = 2010,
                 ExternalId = firstExternalId,
-                Actors = new List<Actor>()
+                Actors = new List<CastMember>()
             };
             var secondMovieWithoutActors = new Movie()
             {
                 Title = "the village",
                 ReleaseDate = 2004,
                 ExternalId = secondExternalId,
-                Actors = new List<Actor>()
+                Actors = new List<CastMember>()
             };
 
             this._actorRepositoryMock
                 .Setup(a => a.GetAll())
-                .Returns(Enumerable.Empty<Actor>());
+                .Returns(Enumerable.Empty<CastMember>());
             this._movieRepositoryMock
                 .Setup(m => m.GetMoviesWithoutActors())
                 .Returns(new Movie[] { firstMovieWithoutActors, secondMovieWithoutActors });
@@ -261,15 +261,15 @@ namespace DepotTests.CRUDTests
         public async Task PopulateDetails_WithLimitOnNumberOfApiCalls_ShouldNotExceedLimit(int maxApiCalls)
         {
             // arrange
-            var firstMovie = new Movie() { Title = "My Cousin Vinny", ReleaseDate = 1992, ExternalId = 101, Actors = new List<Actor>() };
-            var secondMovie = new Movie() { Title = "Payback", ReleaseDate = 1999, ExternalId = 102, Actors = new List<Actor>() };
-            var thirdMovie = new Movie() { Title = "Office Space", ReleaseDate = 1999, ExternalId = 103, Actors = new List<Actor>() };
+            var firstMovie = new Movie() { Title = "My Cousin Vinny", ReleaseDate = 1992, ExternalId = 101, Actors = new List<CastMember>() };
+            var secondMovie = new Movie() { Title = "Payback", ReleaseDate = 1999, ExternalId = 102, Actors = new List<CastMember>() };
+            var thirdMovie = new Movie() { Title = "Office Space", ReleaseDate = 1999, ExternalId = 103, Actors = new List<CastMember>() };
 
             this._movieRepositoryMock
                 .Setup(m => m.GetMoviesWithoutActors())
                 .Returns(new[] { firstMovie, secondMovie, thirdMovie });
 
-            this._actorRepositoryMock.Setup(d => d.GetAll()).Returns(Enumerable.Empty<Actor>());
+            this._actorRepositoryMock.Setup(d => d.GetAll()).Returns(Enumerable.Empty<CastMember>());
 
             this._movieAPIClientMock
                 .Setup(m => m.GetMovieActorsAsync(It.IsAny<int>()))

--- a/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
@@ -45,7 +45,7 @@ namespace DepotTests.CRUDTests
                 .SetupGet(u => u.Movies)
                 .Returns(this._movieRepositoryMock.Object);
             this._unitOfWorkMock
-                .SetupGet(u => u.Actors)
+                .SetupGet(u => u.CastMembers)
                 .Returns(this._actorRepositoryMock.Object);
 
             this._rateLimitConfigMock = new Mock<IRateLimitPolicyConfig>();

--- a/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
@@ -75,7 +75,7 @@ namespace DepotTests.CRUDTests
         public async Task PopulateDetails_WithoutMoviesMissingActors_ShouldNotCallApiClient()
         {
             // arrange
-            this._movieRepositoryMock.Setup(m => m.GetMoviesWithoutActors()).Returns(Enumerable.Empty<Movie>());
+            this._movieRepositoryMock.Setup(m => m.GetMoviesWithoutCastMembers()).Returns(Enumerable.Empty<Movie>());
 
             // act
             await this._movieDetailsFetcherActors.PopulateDetails();
@@ -100,7 +100,7 @@ namespace DepotTests.CRUDTests
                 .Setup(a => a.GetAll())
                 .Returns(new List<CastMember>());
             this._movieRepositoryMock
-                .Setup(m => m.GetMoviesWithoutActors())
+                .Setup(m => m.GetMoviesWithoutCastMembers())
                 .Returns(new Movie[] { movieWithoutActors });
             this._movieAPIClientMock
                 .Setup(m => m.GetMovieActorsAsync(It.IsAny<int>()))
@@ -140,7 +140,7 @@ namespace DepotTests.CRUDTests
                 .Setup(a => a.GetAll())
                 .Returns(new List<CastMember>() { actor });
             this._movieRepositoryMock
-                .Setup(m => m.GetMoviesWithoutActors())
+                .Setup(m => m.GetMoviesWithoutCastMembers())
                 .Returns(new Movie[] { firstMovieWithoutActors, secondMovieWithoutActors });
             this._movieAPIClientMock
                 .Setup(cl => cl.GetMovieActorsAsync(It.Is<int>(i => i == firstExternalId | i == secondExternalId)))
@@ -188,7 +188,7 @@ namespace DepotTests.CRUDTests
                 .Setup(a => a.GetAll())
                 .Returns(Enumerable.Empty<CastMember>());
             this._movieRepositoryMock
-                .Setup(m => m.GetMoviesWithoutActors())
+                .Setup(m => m.GetMoviesWithoutCastMembers())
                 .Returns(new Movie[] { firstMovieWithoutActors, secondMovieWithoutActors });
             this._movieAPIClientMock
                 .Setup(cl => cl.GetMovieActorsAsync(firstExternalId))
@@ -236,7 +236,7 @@ namespace DepotTests.CRUDTests
                 .Setup(a => a.GetAll())
                 .Returns(Enumerable.Empty<CastMember>());
             this._movieRepositoryMock
-                .Setup(m => m.GetMoviesWithoutActors())
+                .Setup(m => m.GetMoviesWithoutCastMembers())
                 .Returns(new Movie[] { firstMovieWithoutActors, secondMovieWithoutActors });
             this._movieAPIClientMock
                 .Setup(cl => cl.GetMovieActorsAsync(firstExternalId))
@@ -266,7 +266,7 @@ namespace DepotTests.CRUDTests
             var thirdMovie = new Movie() { Title = "Office Space", ReleaseDate = 1999, ExternalId = 103, CastMembers = new List<CastMember>() };
 
             this._movieRepositoryMock
-                .Setup(m => m.GetMoviesWithoutActors())
+                .Setup(m => m.GetMoviesWithoutCastMembers())
                 .Returns(new[] { firstMovie, secondMovie, thirdMovie });
 
             this._actorRepositoryMock.Setup(d => d.GetAll()).Returns(Enumerable.Empty<CastMember>());

--- a/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
@@ -21,7 +21,7 @@ namespace DepotTests.CRUDTests
     {
         private readonly Mock<IMovieRepository> _movieRepositoryMock;
 
-        private readonly Mock<IActorRepository> _actorRepositoryMock;
+        private readonly Mock<ICastMemberRepository> _actorRepositoryMock;
 
         private readonly Mock<IUnitOfWork> _unitOfWorkMock;
 
@@ -38,7 +38,7 @@ namespace DepotTests.CRUDTests
         public MovieDetailsFetcherActorsTests()
         {
             this._movieRepositoryMock = new Mock<IMovieRepository>(MockBehavior.Strict);
-            this._actorRepositoryMock = new Mock<IActorRepository>(MockBehavior.Strict);
+            this._actorRepositoryMock = new Mock<ICastMemberRepository>(MockBehavior.Strict);
 
             this._unitOfWorkMock = new Mock<IUnitOfWork>();
             this._unitOfWorkMock

--- a/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherActorsTests.cs
@@ -81,7 +81,7 @@ namespace DepotTests.CRUDTests
             await this._movieDetailsFetcherActors.PopulateDetails();
 
             // assert
-            this._movieAPIClientMock.Verify(cl => cl.GetMovieActorsAsync(It.IsAny<int>()), Times.Never);
+            this._movieAPIClientMock.Verify(cl => cl.GetMovieCastMembersAsync(It.IsAny<int>()), Times.Never);
         }
 
         [Fact]
@@ -103,14 +103,14 @@ namespace DepotTests.CRUDTests
                 .Setup(m => m.GetMoviesWithoutCastMembers())
                 .Returns(new Movie[] { movieWithoutActors });
             this._movieAPIClientMock
-                .Setup(m => m.GetMovieActorsAsync(It.IsAny<int>()))
+                .Setup(m => m.GetMovieCastMembersAsync(It.IsAny<int>()))
                 .ReturnsAsync(Enumerable.Empty<MovieCastMemberResult>());
 
             // act
             await this._movieDetailsFetcherActors.PopulateDetails();
 
             // assert
-            this._movieAPIClientMock.Verify(cl => cl.GetMovieActorsAsync(externalId), Times.Once);
+            this._movieAPIClientMock.Verify(cl => cl.GetMovieCastMembersAsync(externalId), Times.Once);
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace DepotTests.CRUDTests
                 .Setup(m => m.GetMoviesWithoutCastMembers())
                 .Returns(new Movie[] { firstMovieWithoutActors, secondMovieWithoutActors });
             this._movieAPIClientMock
-                .Setup(cl => cl.GetMovieActorsAsync(It.Is<int>(i => i == firstExternalId | i == secondExternalId)))
+                .Setup(cl => cl.GetMovieCastMembersAsync(It.Is<int>(i => i == firstExternalId | i == secondExternalId)))
                 .ReturnsAsync(new MovieCastMemberResult[] { actorResult });
 
             // act
@@ -191,10 +191,10 @@ namespace DepotTests.CRUDTests
                 .Setup(m => m.GetMoviesWithoutCastMembers())
                 .Returns(new Movie[] { firstMovieWithoutActors, secondMovieWithoutActors });
             this._movieAPIClientMock
-                .Setup(cl => cl.GetMovieActorsAsync(firstExternalId))
+                .Setup(cl => cl.GetMovieCastMembersAsync(firstExternalId))
                 .ReturnsAsync(new MovieCastMemberResult[] { firstActorResult });
             this._movieAPIClientMock
-                .Setup(cl => cl.GetMovieActorsAsync(secondExternalId))
+                .Setup(cl => cl.GetMovieCastMembersAsync(secondExternalId))
                 .ReturnsAsync(new MovieCastMemberResult[] { firstActorResult, secondActorResult });
 
             // act
@@ -239,10 +239,10 @@ namespace DepotTests.CRUDTests
                 .Setup(m => m.GetMoviesWithoutCastMembers())
                 .Returns(new Movie[] { firstMovieWithoutActors, secondMovieWithoutActors });
             this._movieAPIClientMock
-                .Setup(cl => cl.GetMovieActorsAsync(firstExternalId))
+                .Setup(cl => cl.GetMovieCastMembersAsync(firstExternalId))
                 .ReturnsAsync(new MovieCastMemberResult[] { firstActorResult });
             this._movieAPIClientMock
-                .Setup(cl => cl.GetMovieActorsAsync(secondExternalId))
+                .Setup(cl => cl.GetMovieCastMembersAsync(secondExternalId))
                 .ReturnsAsync(new MovieCastMemberResult[] { firstActorResult, secondActorResult });
 
             // act
@@ -272,14 +272,14 @@ namespace DepotTests.CRUDTests
             this._actorRepositoryMock.Setup(d => d.GetAll()).Returns(Enumerable.Empty<CastMember>());
 
             this._movieAPIClientMock
-                .Setup(m => m.GetMovieActorsAsync(It.IsAny<int>()))
+                .Setup(m => m.GetMovieCastMembersAsync(It.IsAny<int>()))
                 .ReturnsAsync(new MovieCastMemberResult[] { new MovieCastMemberResult() });
 
             // act
             await this._movieDetailsFetcherActors.PopulateDetails(maxApiCalls);
 
             // assert
-            this._movieAPIClientMock.Verify(m => m.GetMovieActorsAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));
+            this._movieAPIClientMock.Verify(m => m.GetMovieCastMembersAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));
         }
 
     }

--- a/DepotTests/CRUDTests/MovieDetailsFetcherCastMembersTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherCastMembersTests.cs
@@ -156,25 +156,25 @@ namespace DepotTests.CRUDTests
         }
 
         [Fact]
-        public async Task PopulateDetails_WithMovieMissingActors_WithoutSuchActorsInRepo_ShouldBePopulatedWithNewActors()
+        public async Task PopulateDetails_WithMovieMissingCastMembers_WithoutSuchCastMembersInRepo_ShouldBePopulatedWithNewCastMembers()
         {
             // arrange
-            var firstActorResult = new MovieCastMemberResult() { Name = "joaquin phoenix", ExternalId = 201 };
-            var firstActor = (CastMember)firstActorResult;
+            var firstCastMemberResult = new MovieCastMemberResult() { Name = "joaquin phoenix", ExternalId = 201 };
+            var firstCastMember = (CastMember)firstCastMemberResult;
 
-            var secondActorResult = new MovieCastMemberResult() { Name = "adrien brody", ExternalId = 202 };
-            var secondActor = (CastMember)secondActorResult;
+            var secondCastMemberResult = new MovieCastMemberResult() { Name = "adrien brody", ExternalId = 202 };
+            var secondCastMember = (CastMember)secondCastMemberResult;
 
             int firstExternalId = 101;
             int secondExternalId = 102;
-            var firstMovieWithoutActors = new Movie()
+            var firstMovieWithoutCastMembers = new Movie()
             {
                 Title = "i'm still here",
                 ReleaseDate = 2010,
                 ExternalId = firstExternalId,
                 CastMembers = new List<CastMember>()
             };
-            var secondMovieWithoutActors = new Movie()
+            var secondMovieWithoutCastMembers = new Movie()
             {
                 Title = "the village",
                 ReleaseDate = 2004,
@@ -187,13 +187,13 @@ namespace DepotTests.CRUDTests
                 .Returns(Enumerable.Empty<CastMember>());
             this._movieRepositoryMock
                 .Setup(m => m.GetMoviesWithoutCastMembers())
-                .Returns(new Movie[] { firstMovieWithoutActors, secondMovieWithoutActors });
+                .Returns(new Movie[] { firstMovieWithoutCastMembers, secondMovieWithoutCastMembers });
             this._movieAPIClientMock
                 .Setup(cl => cl.GetMovieCastMembersAsync(firstExternalId))
-                .ReturnsAsync(new MovieCastMemberResult[] { firstActorResult });
+                .ReturnsAsync(new MovieCastMemberResult[] { firstCastMemberResult });
             this._movieAPIClientMock
                 .Setup(cl => cl.GetMovieCastMembersAsync(secondExternalId))
-                .ReturnsAsync(new MovieCastMemberResult[] { firstActorResult, secondActorResult });
+                .ReturnsAsync(new MovieCastMemberResult[] { firstCastMemberResult, secondCastMemberResult });
 
             // act
             await this._movieDetailsFetcherCastMembers.PopulateDetails();
@@ -201,8 +201,8 @@ namespace DepotTests.CRUDTests
             // assert
             using (new AssertionScope())
             {
-                firstMovieWithoutActors.CastMembers.Should().BeEquivalentTo(new List<CastMember>() { firstActor });
-                secondMovieWithoutActors.CastMembers.Should().BeEquivalentTo(new List<CastMember>() { firstActor, secondActor });
+                firstMovieWithoutCastMembers.CastMembers.Should().BeEquivalentTo(new List<CastMember>() { firstCastMember });
+                secondMovieWithoutCastMembers.CastMembers.Should().BeEquivalentTo(new List<CastMember>() { firstCastMember, secondCastMember });
             }
         }
 

--- a/DepotTests/CRUDTests/MovieDetailsFetcherCastMembersTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherCastMembersTests.cs
@@ -207,22 +207,22 @@ namespace DepotTests.CRUDTests
         }
 
         [Fact]
-        public async Task PopulateDetails_WithMoviesMissingActors_WithoutSuchActorsInRepo_WithSameActorForAllMovies_ShouldBePopulatedWithTheSameActorEntity()
+        public async Task PopulateDetails_WithMoviesMissingCastMembers_WithoutSuchCastMembersInRepo_WithSameCastMemberForAllMovies_ShouldBePopulatedWithTheSameCastMemberEntity()
         {
             // arrange
-            var firstActorResult = new MovieCastMemberResult() { Name = "joaquin phoenix", ExternalId = 201 };
-            var secondActorResult = new MovieCastMemberResult() { Name = "adrien brody", ExternalId = 202 };
+            var firstCastMemberResult = new MovieCastMemberResult() { Name = "joaquin phoenix", ExternalId = 201 };
+            var secondCastMemberResult = new MovieCastMemberResult() { Name = "adrien brody", ExternalId = 202 };
 
             int firstExternalId = 101;
             int secondExternalId = 102;
-            var firstMovieWithoutActors = new Movie()
+            var firstMovieWithoutCastMembers = new Movie()
             {
                 Title = "i'm still here",
                 ReleaseDate = 2010,
                 ExternalId = firstExternalId,
                 CastMembers = new List<CastMember>()
             };
-            var secondMovieWithoutActors = new Movie()
+            var secondMovieWithoutCastMembers = new Movie()
             {
                 Title = "the village",
                 ReleaseDate = 2004,
@@ -235,22 +235,22 @@ namespace DepotTests.CRUDTests
                 .Returns(Enumerable.Empty<CastMember>());
             this._movieRepositoryMock
                 .Setup(m => m.GetMoviesWithoutCastMembers())
-                .Returns(new Movie[] { firstMovieWithoutActors, secondMovieWithoutActors });
+                .Returns(new Movie[] { firstMovieWithoutCastMembers, secondMovieWithoutCastMembers });
             this._movieAPIClientMock
                 .Setup(cl => cl.GetMovieCastMembersAsync(firstExternalId))
-                .ReturnsAsync(new MovieCastMemberResult[] { firstActorResult });
+                .ReturnsAsync(new MovieCastMemberResult[] { firstCastMemberResult });
             this._movieAPIClientMock
                 .Setup(cl => cl.GetMovieCastMembersAsync(secondExternalId))
-                .ReturnsAsync(new MovieCastMemberResult[] { firstActorResult, secondActorResult });
+                .ReturnsAsync(new MovieCastMemberResult[] { firstCastMemberResult, secondCastMemberResult });
 
             // act
             await this._movieDetailsFetcherCastMembers.PopulateDetails();
 
             // assert
-            firstMovieWithoutActors.CastMembers
-                .First(a => a.ExternalId == firstActorResult.ExternalId)
+            firstMovieWithoutCastMembers.CastMembers
+                .First(a => a.ExternalId == firstCastMemberResult.ExternalId)
                 .Should()
-                .BeSameAs(secondMovieWithoutActors.CastMembers.First(a => a.ExternalId == firstActorResult.ExternalId));
+                .BeSameAs(secondMovieWithoutCastMembers.CastMembers.First(a => a.ExternalId == firstCastMemberResult.ExternalId));
         }
 
         [Theory]

--- a/DepotTests/CRUDTests/MovieDetailsFetcherCastMembersTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherCastMembersTests.cs
@@ -70,7 +70,7 @@ namespace DepotTests.CRUDTests
         }
 
         [Fact]
-        public async Task PopulateDetails_WithoutMoviesMissingActors_ShouldNotCallApiClient()
+        public async Task PopulateDetails_WithoutMoviesMissingCastMembers_ShouldNotCallApiClient()
         {
             // arrange
             this._movieRepositoryMock.Setup(m => m.GetMoviesWithoutCastMembers()).Returns(Enumerable.Empty<Movie>());

--- a/DepotTests/CRUDTests/MovieDetailsFetcherCastMembersTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherCastMembersTests.cs
@@ -83,11 +83,11 @@ namespace DepotTests.CRUDTests
         }
 
         [Fact]
-        public async Task PopulateDetails_WithMoviesMissingActors_ShouldCallMovieAPIClient()
+        public async Task PopulateDetails_WithMoviesMissingCastMembers_ShouldCallMovieAPIClient()
         {
             // arrange
             int externalId = 101;
-            var movieWithoutActors = new Movie()
+            var movieWithoutCastMembers = new Movie()
             {
                 Title = "the fly",
                 ReleaseDate = 1986,
@@ -99,7 +99,7 @@ namespace DepotTests.CRUDTests
                 .Returns(new List<CastMember>());
             this._movieRepositoryMock
                 .Setup(m => m.GetMoviesWithoutCastMembers())
-                .Returns(new Movie[] { movieWithoutActors });
+                .Returns(new Movie[] { movieWithoutCastMembers });
             this._movieAPIClientMock
                 .Setup(m => m.GetMovieCastMembersAsync(It.IsAny<int>()))
                 .ReturnsAsync(Enumerable.Empty<MovieCastMemberResult>());
@@ -112,22 +112,22 @@ namespace DepotTests.CRUDTests
         }
 
         [Fact]
-        public async Task PopulateDetails_WithMovieMissingActors_WithExistingActorResultInRepo_ShouldBePopulatedWithExistingActor()
+        public async Task PopulateDetails_WithMovieMissingCastMembers_WithExistingCastMemberResultInRepo_ShouldBePopulatedWithExistingCastMember()
         {
             // arrange
-            var actorResult = new MovieCastMemberResult() { Name = "joaquin phoenix", ExternalId = 201 };
-            var actor = (CastMember)actorResult;
+            var castMemberResult = new MovieCastMemberResult() { Name = "joaquin phoenix", ExternalId = 201 };
+            var castMember = (CastMember)castMemberResult;
 
             int firstExternalId = 101;
             int secondExternalId = 102;
-            var firstMovieWithoutActors = new Movie()
+            var firstMovieWithoutCastMembers = new Movie()
             {
                 Title = "i'm still here",
                 ReleaseDate = 2010,
                 ExternalId = firstExternalId,
                 CastMembers = new List<CastMember>()
             };
-            var secondMovieWithoutActors = new Movie()
+            var secondMovieWithoutCastMembers = new Movie()
             {
                 Title = "joker",
                 ReleaseDate = 2019,
@@ -136,13 +136,13 @@ namespace DepotTests.CRUDTests
             };
             this._castMemberRepositoryMock
                 .Setup(a => a.GetAll())
-                .Returns(new List<CastMember>() { actor });
+                .Returns(new List<CastMember>() { castMember });
             this._movieRepositoryMock
                 .Setup(m => m.GetMoviesWithoutCastMembers())
-                .Returns(new Movie[] { firstMovieWithoutActors, secondMovieWithoutActors });
+                .Returns(new Movie[] { firstMovieWithoutCastMembers, secondMovieWithoutCastMembers });
             this._movieAPIClientMock
                 .Setup(cl => cl.GetMovieCastMembersAsync(It.Is<int>(i => i == firstExternalId | i == secondExternalId)))
-                .ReturnsAsync(new MovieCastMemberResult[] { actorResult });
+                .ReturnsAsync(new MovieCastMemberResult[] { castMemberResult });
 
             // act
             await this._movieDetailsFetcherCastMembers.PopulateDetails();
@@ -150,8 +150,8 @@ namespace DepotTests.CRUDTests
             // assert
             using (new AssertionScope())
             {
-                firstMovieWithoutActors.CastMembers.FirstOrDefault().Should().BeSameAs(actor);
-                secondMovieWithoutActors.CastMembers.FirstOrDefault().Should().BeSameAs(actor);
+                firstMovieWithoutCastMembers.CastMembers.FirstOrDefault().Should().BeSameAs(castMember);
+                secondMovieWithoutCastMembers.CastMembers.FirstOrDefault().Should().BeSameAs(castMember);
             }
         }
 

--- a/DepotTests/CRUDTests/MovieDetailsFetcherCastMembersTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherCastMembersTests.cs
@@ -5,13 +5,11 @@ using FluentAssertions.Execution;
 using System.Threading.Tasks;
 using System.Linq;
 using System.Collections.Generic;
-
 using FilmCRUD;
 using FilmDomain.Entities;
 using FilmDomain.Interfaces;
 using MovieAPIClients;
 using MovieAPIClients.Interfaces;
-using FilmCRUD.Interfaces;
 using ConfigUtils.Interfaces;
 using System;
 

--- a/DepotTests/CRUDTests/MovieDetailsFetcherCastMembersTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherCastMembersTests.cs
@@ -19,7 +19,7 @@ namespace DepotTests.CRUDTests
     {
         private readonly Mock<IMovieRepository> _movieRepositoryMock;
 
-        private readonly Mock<ICastMemberRepository> _actorRepositoryMock;
+        private readonly Mock<ICastMemberRepository> _castMemberRepositoryMock;
 
         private readonly Mock<IUnitOfWork> _unitOfWorkMock;
 
@@ -31,12 +31,12 @@ namespace DepotTests.CRUDTests
 
         private readonly Mock<IMovieAPIClient> _movieAPIClientMock;
 
-        private readonly MovieDetailsFetcherCastMembers _movieDetailsFetcherActors;
+        private readonly MovieDetailsFetcherCastMembers _movieDetailsFetcherCastMembers;
 
         public MovieDetailsFetcherCastMembersTests()
         {
             this._movieRepositoryMock = new Mock<IMovieRepository>(MockBehavior.Strict);
-            this._actorRepositoryMock = new Mock<ICastMemberRepository>(MockBehavior.Strict);
+            this._castMemberRepositoryMock = new Mock<ICastMemberRepository>(MockBehavior.Strict);
 
             this._unitOfWorkMock = new Mock<IUnitOfWork>();
             this._unitOfWorkMock
@@ -44,7 +44,7 @@ namespace DepotTests.CRUDTests
                 .Returns(this._movieRepositoryMock.Object);
             this._unitOfWorkMock
                 .SetupGet(u => u.CastMembers)
-                .Returns(this._actorRepositoryMock.Object);
+                .Returns(this._castMemberRepositoryMock.Object);
 
             this._rateLimitConfigMock = new Mock<IRateLimitPolicyConfig>();
             this._retryConfigMock = new Mock<IRetryPolicyConfig>();
@@ -63,7 +63,7 @@ namespace DepotTests.CRUDTests
 
             this._movieAPIClientMock = new Mock<IMovieAPIClient>();
 
-            this._movieDetailsFetcherActors = new MovieDetailsFetcherCastMembers(
+            this._movieDetailsFetcherCastMembers = new MovieDetailsFetcherCastMembers(
                 this._unitOfWorkMock.Object,
                 this._appSettingsManagerMock.Object,
                 this._movieAPIClientMock.Object);
@@ -76,7 +76,7 @@ namespace DepotTests.CRUDTests
             this._movieRepositoryMock.Setup(m => m.GetMoviesWithoutCastMembers()).Returns(Enumerable.Empty<Movie>());
 
             // act
-            await this._movieDetailsFetcherActors.PopulateDetails();
+            await this._movieDetailsFetcherCastMembers.PopulateDetails();
 
             // assert
             this._movieAPIClientMock.Verify(cl => cl.GetMovieCastMembersAsync(It.IsAny<int>()), Times.Never);
@@ -94,7 +94,7 @@ namespace DepotTests.CRUDTests
                 ExternalId = externalId,
                 CastMembers = new List<CastMember>()
             };
-            this._actorRepositoryMock
+            this._castMemberRepositoryMock
                 .Setup(a => a.GetAll())
                 .Returns(new List<CastMember>());
             this._movieRepositoryMock
@@ -105,7 +105,7 @@ namespace DepotTests.CRUDTests
                 .ReturnsAsync(Enumerable.Empty<MovieCastMemberResult>());
 
             // act
-            await this._movieDetailsFetcherActors.PopulateDetails();
+            await this._movieDetailsFetcherCastMembers.PopulateDetails();
 
             // assert
             this._movieAPIClientMock.Verify(cl => cl.GetMovieCastMembersAsync(externalId), Times.Once);
@@ -134,7 +134,7 @@ namespace DepotTests.CRUDTests
                 ExternalId = secondExternalId,
                 CastMembers = new List<CastMember>()
             };
-            this._actorRepositoryMock
+            this._castMemberRepositoryMock
                 .Setup(a => a.GetAll())
                 .Returns(new List<CastMember>() { actor });
             this._movieRepositoryMock
@@ -145,7 +145,7 @@ namespace DepotTests.CRUDTests
                 .ReturnsAsync(new MovieCastMemberResult[] { actorResult });
 
             // act
-            await this._movieDetailsFetcherActors.PopulateDetails();
+            await this._movieDetailsFetcherCastMembers.PopulateDetails();
 
             // assert
             using (new AssertionScope())
@@ -182,7 +182,7 @@ namespace DepotTests.CRUDTests
                 CastMembers = new List<CastMember>()
             };
 
-            this._actorRepositoryMock
+            this._castMemberRepositoryMock
                 .Setup(a => a.GetAll())
                 .Returns(Enumerable.Empty<CastMember>());
             this._movieRepositoryMock
@@ -196,7 +196,7 @@ namespace DepotTests.CRUDTests
                 .ReturnsAsync(new MovieCastMemberResult[] { firstActorResult, secondActorResult });
 
             // act
-            await this._movieDetailsFetcherActors.PopulateDetails();
+            await this._movieDetailsFetcherCastMembers.PopulateDetails();
 
             // assert
             using (new AssertionScope())
@@ -230,7 +230,7 @@ namespace DepotTests.CRUDTests
                 CastMembers = new List<CastMember>()
             };
 
-            this._actorRepositoryMock
+            this._castMemberRepositoryMock
                 .Setup(a => a.GetAll())
                 .Returns(Enumerable.Empty<CastMember>());
             this._movieRepositoryMock
@@ -244,7 +244,7 @@ namespace DepotTests.CRUDTests
                 .ReturnsAsync(new MovieCastMemberResult[] { firstActorResult, secondActorResult });
 
             // act
-            await this._movieDetailsFetcherActors.PopulateDetails();
+            await this._movieDetailsFetcherCastMembers.PopulateDetails();
 
             // assert
             firstMovieWithoutActors.CastMembers
@@ -267,14 +267,14 @@ namespace DepotTests.CRUDTests
                 .Setup(m => m.GetMoviesWithoutCastMembers())
                 .Returns(new[] { firstMovie, secondMovie, thirdMovie });
 
-            this._actorRepositoryMock.Setup(d => d.GetAll()).Returns(Enumerable.Empty<CastMember>());
+            this._castMemberRepositoryMock.Setup(d => d.GetAll()).Returns(Enumerable.Empty<CastMember>());
 
             this._movieAPIClientMock
                 .Setup(m => m.GetMovieCastMembersAsync(It.IsAny<int>()))
                 .ReturnsAsync(new MovieCastMemberResult[] { new MovieCastMemberResult() });
 
             // act
-            await this._movieDetailsFetcherActors.PopulateDetails(maxApiCalls);
+            await this._movieDetailsFetcherCastMembers.PopulateDetails(maxApiCalls);
 
             // assert
             this._movieAPIClientMock.Verify(m => m.GetMovieCastMembersAsync(It.IsAny<int>()), Times.Exactly(maxApiCalls));

--- a/DepotTests/CRUDTests/MovieDetailsFetcherCastMembersTests.cs
+++ b/DepotTests/CRUDTests/MovieDetailsFetcherCastMembersTests.cs
@@ -17,7 +17,7 @@ using System;
 
 namespace DepotTests.CRUDTests
 {
-    public class MovieDetailsFetcherActorsTests
+    public class MovieDetailsFetcherCastMembersTests
     {
         private readonly Mock<IMovieRepository> _movieRepositoryMock;
 
@@ -35,7 +35,7 @@ namespace DepotTests.CRUDTests
 
         private readonly MovieDetailsFetcherCastMembers _movieDetailsFetcherActors;
 
-        public MovieDetailsFetcherActorsTests()
+        public MovieDetailsFetcherCastMembersTests()
         {
             this._movieRepositoryMock = new Mock<IMovieRepository>(MockBehavior.Strict);
             this._actorRepositoryMock = new Mock<ICastMemberRepository>(MockBehavior.Strict);

--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -72,18 +72,18 @@ namespace DepotTests.CRUDTests
         public void GetMoviesWithActors_WithProvidedActors_ShouldReturnCorrectMovies()
         {
             // arrange
-            var firstActor = new Actor() { Name = "jeff goldblum" };
-            var secondActor = new Actor() { Name = "bill pullman" };
-            var thirdActor = new Actor() { Name = "jim carrey" };
+            var firstActor = new CastMember() { Name = "jeff goldblum" };
+            var secondActor = new CastMember() { Name = "bill pullman" };
+            var thirdActor = new CastMember() { Name = "jim carrey" };
 
             var firstMovie = new Movie() {
-                Title = "the fly", ReleaseDate = 1986, Actors = new Actor[] { firstActor }
+                Title = "the fly", ReleaseDate = 1986, Actors = new CastMember[] { firstActor }
             };
             var secondMovie = new Movie() {
-                Title = "independence day", ReleaseDate = 1996, Actors = new Actor[] { firstActor, secondActor }
+                Title = "independence day", ReleaseDate = 1996, Actors = new CastMember[] { firstActor, secondActor }
             };
             var thirdMovie = new Movie() {
-                Title = "dumb and dumber", ReleaseDate = 1994, Actors = new Actor[] { thirdActor }
+                Title = "dumb and dumber", ReleaseDate = 1994, Actors = new CastMember[] { thirdActor }
             };
 
             var visit = new MovieWarehouseVisit() { VisitDateTime = DateTime.ParseExact("20220101", "yyyyMMdd", null) };
@@ -192,15 +192,15 @@ namespace DepotTests.CRUDTests
         public void GetCountByActor_ShouldReturnCorrectCount()
         {
             // arrange
-            var firstActor = new Actor() { Name = "jeff goldblum" };
-            var secondActor = new Actor() { Name = "bill pullman" };
-            var thirdActor = new Actor() { Name = "jim carrey" };
+            var firstActor = new CastMember() { Name = "jeff goldblum" };
+            var secondActor = new CastMember() { Name = "bill pullman" };
+            var thirdActor = new CastMember() { Name = "jim carrey" };
 
-            var firstMovie = new Movie() { Title = "the fly", ReleaseDate = 1986, Actors = new Actor[] { firstActor, secondActor } };
-            var secondMovie = new Movie() { Title = "independence day", ReleaseDate = 1996, Actors = new Actor[] { firstActor } };
-            var thirdMovie = new Movie() { Title = "dumb and dumber", ReleaseDate = 1994, Actors = new Actor[] { thirdActor } };
-            var fourthMovie = new Movie() { Title = "begotten", ReleaseDate = 1989, Actors = Array.Empty<Actor>() };
-            var fifthMovie = new Movie() { Title = "gummo", ReleaseDate = 1997, Actors = Array.Empty<Actor>() };
+            var firstMovie = new Movie() { Title = "the fly", ReleaseDate = 1986, Actors = new CastMember[] { firstActor, secondActor } };
+            var secondMovie = new Movie() { Title = "independence day", ReleaseDate = 1996, Actors = new CastMember[] { firstActor } };
+            var thirdMovie = new Movie() { Title = "dumb and dumber", ReleaseDate = 1994, Actors = new CastMember[] { thirdActor } };
+            var fourthMovie = new Movie() { Title = "begotten", ReleaseDate = 1989, Actors = Array.Empty<CastMember>() };
+            var fifthMovie = new Movie() { Title = "gummo", ReleaseDate = 1997, Actors = Array.Empty<CastMember>() };
 
             var moviesInVisit = new Movie[] { firstMovie, secondMovie, thirdMovie, fourthMovie, fifthMovie };
 
@@ -211,13 +211,13 @@ namespace DepotTests.CRUDTests
                 .Returns(moviesInVisit);
 
             // act
-            IEnumerable<KeyValuePair<Actor, int>> actual = this._scanMoviesManager.GetCountByActor(visit, out int withoutActors);
+            IEnumerable<KeyValuePair<CastMember, int>> actual = this._scanMoviesManager.GetCountByActor(visit, out int withoutActors);
 
             // assert
-            var expected = new List<KeyValuePair<Actor, int>>() {
-                new KeyValuePair<Actor, int>(firstActor, 2),
-                new KeyValuePair<Actor, int>(secondActor, 1),
-                new KeyValuePair<Actor, int>(thirdActor, 1)
+            var expected = new List<KeyValuePair<CastMember, int>>() {
+                new KeyValuePair<CastMember, int>(firstActor, 2),
+                new KeyValuePair<CastMember, int>(secondActor, 1),
+                new KeyValuePair<CastMember, int>(thirdActor, 1)
             };
 
             using (new AssertionScope())

--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -189,16 +189,16 @@ namespace DepotTests.CRUDTests
         }
 
         [Fact]
-        public void GetCountByActor_ShouldReturnCorrectCount()
+        public void GetCountByCastMember_ShouldReturnCorrectCount()
         {
             // arrange
-            var firstActor = new CastMember() { Name = "jeff goldblum" };
-            var secondActor = new CastMember() { Name = "bill pullman" };
-            var thirdActor = new CastMember() { Name = "jim carrey" };
+            var firstCastMember = new CastMember() { Name = "jeff goldblum" };
+            var secondCastMember = new CastMember() { Name = "bill pullman" };
+            var thirdCastMember = new CastMember() { Name = "jim carrey" };
 
-            var firstMovie = new Movie() { Title = "the fly", ReleaseDate = 1986, CastMembers = new CastMember[] { firstActor, secondActor } };
-            var secondMovie = new Movie() { Title = "independence day", ReleaseDate = 1996, CastMembers = new CastMember[] { firstActor } };
-            var thirdMovie = new Movie() { Title = "dumb and dumber", ReleaseDate = 1994, CastMembers = new CastMember[] { thirdActor } };
+            var firstMovie = new Movie() { Title = "the fly", ReleaseDate = 1986, CastMembers = new CastMember[] { firstCastMember, secondCastMember } };
+            var secondMovie = new Movie() { Title = "independence day", ReleaseDate = 1996, CastMembers = new CastMember[] { firstCastMember } };
+            var thirdMovie = new Movie() { Title = "dumb and dumber", ReleaseDate = 1994, CastMembers = new CastMember[] { thirdCastMember } };
             var fourthMovie = new Movie() { Title = "begotten", ReleaseDate = 1989, CastMembers = Array.Empty<CastMember>() };
             var fifthMovie = new Movie() { Title = "gummo", ReleaseDate = 1997, CastMembers = Array.Empty<CastMember>() };
 
@@ -211,19 +211,19 @@ namespace DepotTests.CRUDTests
                 .Returns(moviesInVisit);
 
             // act
-            IEnumerable<KeyValuePair<CastMember, int>> actual = this._scanMoviesManager.GetCountByCastMember(visit, out int withoutActors);
+            IEnumerable<KeyValuePair<CastMember, int>> actual = this._scanMoviesManager.GetCountByCastMember(visit, out int withoutCastMembers);
 
             // assert
             var expected = new List<KeyValuePair<CastMember, int>>() {
-                new KeyValuePair<CastMember, int>(firstActor, 2),
-                new KeyValuePair<CastMember, int>(secondActor, 1),
-                new KeyValuePair<CastMember, int>(thirdActor, 1)
+                new KeyValuePair<CastMember, int>(firstCastMember, 2),
+                new KeyValuePair<CastMember, int>(secondCastMember, 1),
+                new KeyValuePair<CastMember, int>(thirdCastMember, 1)
             };
 
             using (new AssertionScope())
             {
                 actual.Should().BeEquivalentTo(expected);
-                withoutActors.Should().Be(moviesInVisit.Where(m => !m.CastMembers.Any()).Count());
+                withoutCastMembers.Should().Be(moviesInVisit.Where(m => !m.CastMembers.Any()).Count());
             }
         }
 

--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -69,21 +69,21 @@ namespace DepotTests.CRUDTests
         }
 
         [Fact]
-        public void GetMoviesWithActors_WithProvidedActors_ShouldReturnCorrectMovies()
+        public void GetMoviesWithActors_WithProvidedCastMembers_ShouldReturnCorrectMovies()
         {
             // arrange
-            var firstActor = new CastMember() { Name = "jeff goldblum" };
-            var secondActor = new CastMember() { Name = "bill pullman" };
-            var thirdActor = new CastMember() { Name = "jim carrey" };
+            var firstCastMember = new CastMember() { Name = "jeff goldblum" };
+            var secondCastMember = new CastMember() { Name = "bill pullman" };
+            var thirdCastMember = new CastMember() { Name = "jim carrey" };
 
             var firstMovie = new Movie() {
-                Title = "the fly", ReleaseDate = 1986, CastMembers = new CastMember[] { firstActor }
+                Title = "the fly", ReleaseDate = 1986, CastMembers = new CastMember[] { firstCastMember }
             };
             var secondMovie = new Movie() {
-                Title = "independence day", ReleaseDate = 1996, CastMembers = new CastMember[] { firstActor, secondActor }
+                Title = "independence day", ReleaseDate = 1996, CastMembers = new CastMember[] { firstCastMember, secondCastMember }
             };
             var thirdMovie = new Movie() {
-                Title = "dumb and dumber", ReleaseDate = 1994, CastMembers = new CastMember[] { thirdActor }
+                Title = "dumb and dumber", ReleaseDate = 1994, CastMembers = new CastMember[] { thirdCastMember }
             };
 
             var visit = new MovieWarehouseVisit() { VisitDateTime = DateTime.ParseExact("20220101", "yyyyMMdd", null) };
@@ -93,7 +93,7 @@ namespace DepotTests.CRUDTests
                 .Returns(new Movie[] { firstMovie, secondMovie, thirdMovie });
 
             // act
-            IEnumerable<Movie> actual = this._scanMoviesManager.GetMoviesWithCastMembers(visit, firstActor, secondActor);
+            IEnumerable<Movie> actual = this._scanMoviesManager.GetMoviesWithCastMembers(visit, firstCastMember, secondCastMember);
 
             // assert
             actual.Should().BeEquivalentTo(new Movie[] { firstMovie, secondMovie });

--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -93,7 +93,7 @@ namespace DepotTests.CRUDTests
                 .Returns(new Movie[] { firstMovie, secondMovie, thirdMovie });
 
             // act
-            IEnumerable<Movie> actual = this._scanMoviesManager.GetMoviesWithActors(visit, firstActor, secondActor);
+            IEnumerable<Movie> actual = this._scanMoviesManager.GetMoviesWithCastMembers(visit, firstActor, secondActor);
 
             // assert
             actual.Should().BeEquivalentTo(new Movie[] { firstMovie, secondMovie });

--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -8,7 +8,6 @@ using FilmDomain.Entities;
 using FilmDomain.Interfaces;
 using FilmCRUD;
 using FluentAssertions.Execution;
-using Microsoft.VisualBasic;
 
 namespace DepotTests.CRUDTests
 {

--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -77,13 +77,13 @@ namespace DepotTests.CRUDTests
             var thirdActor = new CastMember() { Name = "jim carrey" };
 
             var firstMovie = new Movie() {
-                Title = "the fly", ReleaseDate = 1986, Actors = new CastMember[] { firstActor }
+                Title = "the fly", ReleaseDate = 1986, CastMembers = new CastMember[] { firstActor }
             };
             var secondMovie = new Movie() {
-                Title = "independence day", ReleaseDate = 1996, Actors = new CastMember[] { firstActor, secondActor }
+                Title = "independence day", ReleaseDate = 1996, CastMembers = new CastMember[] { firstActor, secondActor }
             };
             var thirdMovie = new Movie() {
-                Title = "dumb and dumber", ReleaseDate = 1994, Actors = new CastMember[] { thirdActor }
+                Title = "dumb and dumber", ReleaseDate = 1994, CastMembers = new CastMember[] { thirdActor }
             };
 
             var visit = new MovieWarehouseVisit() { VisitDateTime = DateTime.ParseExact("20220101", "yyyyMMdd", null) };
@@ -196,11 +196,11 @@ namespace DepotTests.CRUDTests
             var secondActor = new CastMember() { Name = "bill pullman" };
             var thirdActor = new CastMember() { Name = "jim carrey" };
 
-            var firstMovie = new Movie() { Title = "the fly", ReleaseDate = 1986, Actors = new CastMember[] { firstActor, secondActor } };
-            var secondMovie = new Movie() { Title = "independence day", ReleaseDate = 1996, Actors = new CastMember[] { firstActor } };
-            var thirdMovie = new Movie() { Title = "dumb and dumber", ReleaseDate = 1994, Actors = new CastMember[] { thirdActor } };
-            var fourthMovie = new Movie() { Title = "begotten", ReleaseDate = 1989, Actors = Array.Empty<CastMember>() };
-            var fifthMovie = new Movie() { Title = "gummo", ReleaseDate = 1997, Actors = Array.Empty<CastMember>() };
+            var firstMovie = new Movie() { Title = "the fly", ReleaseDate = 1986, CastMembers = new CastMember[] { firstActor, secondActor } };
+            var secondMovie = new Movie() { Title = "independence day", ReleaseDate = 1996, CastMembers = new CastMember[] { firstActor } };
+            var thirdMovie = new Movie() { Title = "dumb and dumber", ReleaseDate = 1994, CastMembers = new CastMember[] { thirdActor } };
+            var fourthMovie = new Movie() { Title = "begotten", ReleaseDate = 1989, CastMembers = Array.Empty<CastMember>() };
+            var fifthMovie = new Movie() { Title = "gummo", ReleaseDate = 1997, CastMembers = Array.Empty<CastMember>() };
 
             var moviesInVisit = new Movie[] { firstMovie, secondMovie, thirdMovie, fourthMovie, fifthMovie };
 
@@ -223,7 +223,7 @@ namespace DepotTests.CRUDTests
             using (new AssertionScope())
             {
                 actual.Should().BeEquivalentTo(expected);
-                withoutActors.Should().Be(moviesInVisit.Where(m => !m.Actors.Any()).Count());
+                withoutActors.Should().Be(moviesInVisit.Where(m => !m.CastMembers.Any()).Count());
             }
         }
 

--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -100,7 +100,7 @@ namespace DepotTests.CRUDTests
         }
 
         [Fact]
-        public void GetMoviesWithDirectors_WithProvidedActors_ShouldReturnCorrectMovies()
+        public void GetMoviesWithDirectors_WithProvidedDirectors_ShouldReturnCorrectMovies()
         {
             // arrange
             var firstDirector = new Director() { Name = "benny safdie" };

--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -211,7 +211,7 @@ namespace DepotTests.CRUDTests
                 .Returns(moviesInVisit);
 
             // act
-            IEnumerable<KeyValuePair<CastMember, int>> actual = this._scanMoviesManager.GetCountByActor(visit, out int withoutActors);
+            IEnumerable<KeyValuePair<CastMember, int>> actual = this._scanMoviesManager.GetCountByCastMember(visit, out int withoutActors);
 
             // assert
             var expected = new List<KeyValuePair<CastMember, int>>() {

--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -69,7 +69,7 @@ namespace DepotTests.CRUDTests
         }
 
         [Fact]
-        public void GetMoviesWithActors_WithProvidedCastMembers_ShouldReturnCorrectMovies()
+        public void GetMoviesWithCastMembers_WithProvidedCastMembers_ShouldReturnCorrectMovies()
         {
             // arrange
             var firstCastMember = new CastMember() { Name = "jeff goldblum" };

--- a/DepotTests/FilmDomainTests/EntityExtensionsTests.cs
+++ b/DepotTests/FilmDomainTests/EntityExtensionsTests.cs
@@ -83,16 +83,16 @@ namespace DepotTests.FilmDomainTests
         public void GetEntitiesFromNameFuzzyMatching_WithoutRemoveDiacritics_ShouldReturnCorrectMatches(string nameToSearch)
         {
             // arrange
-            var firstActor = new CastMember() { Name = "{/% Benoît Pöelvóorde", Id = 0};
-            var secondActor = new CastMember() { Name = ":!!  benoit /& PoeLVOOrdE ", Id = 1 };
-            var thirdActor = new CastMember() { Name = "Zbigniew Zamachowski", Id = 2 };
-            var allActors = new CastMember[] { firstActor, secondActor, thirdActor };
+            var firstCastMember = new CastMember() { Name = "{/% Benoît Pöelvóorde", Id = 0};
+            var secondCastMember = new CastMember() { Name = ":!!  benoit /& PoeLVOOrdE ", Id = 1 };
+            var thirdCastMember = new CastMember() { Name = "Zbigniew Zamachowski", Id = 2 };
+            var allCastMembers = new CastMember[] { firstCastMember, secondCastMember, thirdCastMember };
 
             // act
-            IEnumerable<CastMember> searchResult = allActors.GetEntitiesFromNameFuzzyMatching(nameToSearch, removeDiacritics: false);
+            IEnumerable<CastMember> searchResult = allCastMembers.GetEntitiesFromNameFuzzyMatching(nameToSearch, removeDiacritics: false);
 
             // assert
-            searchResult.Should().BeEquivalentTo(new CastMember[] { secondActor });
+            searchResult.Should().BeEquivalentTo(new CastMember[] { secondCastMember });
 
         }
 

--- a/DepotTests/FilmDomainTests/EntityExtensionsTests.cs
+++ b/DepotTests/FilmDomainTests/EntityExtensionsTests.cs
@@ -63,16 +63,16 @@ namespace DepotTests.FilmDomainTests
         public void GetEntitiesFromNameFuzzyMatching_WithRemoveDiacritics_ShouldReturnCorrectMatches(string nameToSearch)
         {
             // arrange
-            var firstActor = new CastMember() { Name = "!~~Benoît Pöelvóorde", Id = 0};
-            var secondActor = new CastMember() { Name = " ([]) - benoit -^^ PoeLVOOrdE *+", Id = 1 };
-            var thirdActor = new CastMember() { Name = "Zbigniew Zamachowski", Id = 2 };
-            var allActors = new CastMember[] { firstActor, secondActor, thirdActor };
+            var firstCastMember = new CastMember() { Name = "!~~Benoît Pöelvóorde", Id = 0};
+            var secondCastMember = new CastMember() { Name = " ([]) - benoit -^^ PoeLVOOrdE *+", Id = 1 };
+            var thirdCastMember = new CastMember() { Name = "Zbigniew Zamachowski", Id = 2 };
+            var allCastMembers = new CastMember[] { firstCastMember, secondCastMember, thirdCastMember };
 
             // act
-            IEnumerable<CastMember> searchResult = allActors.GetEntitiesFromNameFuzzyMatching(nameToSearch, removeDiacritics: true);
+            IEnumerable<CastMember> searchResult = allCastMembers.GetEntitiesFromNameFuzzyMatching(nameToSearch, removeDiacritics: true);
 
             // assert
-            searchResult.Should().BeEquivalentTo(new CastMember[] { firstActor, secondActor });
+            searchResult.Should().BeEquivalentTo(new CastMember[] { firstCastMember, secondCastMember });
         }
 
         [Theory]

--- a/DepotTests/FilmDomainTests/EntityExtensionsTests.cs
+++ b/DepotTests/FilmDomainTests/EntityExtensionsTests.cs
@@ -63,16 +63,16 @@ namespace DepotTests.FilmDomainTests
         public void GetEntitiesFromNameFuzzyMatching_WithRemoveDiacritics_ShouldReturnCorrectMatches(string nameToSearch)
         {
             // arrange
-            var firstActor = new Actor() { Name = "!~~Benoît Pöelvóorde", Id = 0};
-            var secondActor = new Actor() { Name = " ([]) - benoit -^^ PoeLVOOrdE *+", Id = 1 };
-            var thirdActor = new Actor() { Name = "Zbigniew Zamachowski", Id = 2 };
-            var allActors = new Actor[] { firstActor, secondActor, thirdActor };
+            var firstActor = new CastMember() { Name = "!~~Benoît Pöelvóorde", Id = 0};
+            var secondActor = new CastMember() { Name = " ([]) - benoit -^^ PoeLVOOrdE *+", Id = 1 };
+            var thirdActor = new CastMember() { Name = "Zbigniew Zamachowski", Id = 2 };
+            var allActors = new CastMember[] { firstActor, secondActor, thirdActor };
 
             // act
-            IEnumerable<Actor> searchResult = allActors.GetEntitiesFromNameFuzzyMatching(nameToSearch, removeDiacritics: true);
+            IEnumerable<CastMember> searchResult = allActors.GetEntitiesFromNameFuzzyMatching(nameToSearch, removeDiacritics: true);
 
             // assert
-            searchResult.Should().BeEquivalentTo(new Actor[] { firstActor, secondActor });
+            searchResult.Should().BeEquivalentTo(new CastMember[] { firstActor, secondActor });
         }
 
         [Theory]
@@ -83,16 +83,16 @@ namespace DepotTests.FilmDomainTests
         public void GetEntitiesFromNameFuzzyMatching_WithoutRemoveDiacritics_ShouldReturnCorrectMatches(string nameToSearch)
         {
             // arrange
-            var firstActor = new Actor() { Name = "{/% Benoît Pöelvóorde", Id = 0};
-            var secondActor = new Actor() { Name = ":!!  benoit /& PoeLVOOrdE ", Id = 1 };
-            var thirdActor = new Actor() { Name = "Zbigniew Zamachowski", Id = 2 };
-            var allActors = new Actor[] { firstActor, secondActor, thirdActor };
+            var firstActor = new CastMember() { Name = "{/% Benoît Pöelvóorde", Id = 0};
+            var secondActor = new CastMember() { Name = ":!!  benoit /& PoeLVOOrdE ", Id = 1 };
+            var thirdActor = new CastMember() { Name = "Zbigniew Zamachowski", Id = 2 };
+            var allActors = new CastMember[] { firstActor, secondActor, thirdActor };
 
             // act
-            IEnumerable<Actor> searchResult = allActors.GetEntitiesFromNameFuzzyMatching(nameToSearch, removeDiacritics: false);
+            IEnumerable<CastMember> searchResult = allActors.GetEntitiesFromNameFuzzyMatching(nameToSearch, removeDiacritics: false);
 
             // assert
-            searchResult.Should().BeEquivalentTo(new Actor[] { secondActor });
+            searchResult.Should().BeEquivalentTo(new CastMember[] { secondActor });
 
         }
 

--- a/FilmCRUD/MovieDetailsFetcherAbstract.cs
+++ b/FilmCRUD/MovieDetailsFetcherAbstract.cs
@@ -58,7 +58,7 @@ namespace FilmCRUD
         public abstract IEnumerable<TDetailEntity> GetExistingDetailEntitiesInRepo();
 
         // should be asynchronous and call one of the methods of IMovieAPIClient;
-        // each concrete subclass should invoke the relevant method, e.g., GetMovieActorsAsync, GetMovieGenresAsync etc...
+        // each concrete subclass should invoke the relevant method, e.g., GetMovieCastMembersAsync, GetMovieGenresAsync etc...
         public abstract Task<IEnumerable<TAPIResult>> GetMovieDetailsFromApiAsync(int externalId);
 
         // TAPIResult to TDetailEntity conversion

--- a/FilmCRUD/MovieDetailsFetcherActors.cs
+++ b/FilmCRUD/MovieDetailsFetcherActors.cs
@@ -34,7 +34,7 @@ namespace FilmCRUD
 
         public override IEnumerable<Movie> GetMoviesWithoutDetails() => this._unitOfWork.Movies.GetMoviesWithoutActors();
 
-        // explicit cast is defined in MovieActorResult
+        // explicit cast is defined in MovieCastMemberResult
         public override Actor CastApiResultToDetailEntity(MovieActorResult apiresult) => (Actor)apiresult;
 
         public override void AddDetailsToMovieEntity(Movie movie, IEnumerable<Actor> details)

--- a/FilmCRUD/MovieDetailsFetcherActors.cs
+++ b/FilmCRUD/MovieDetailsFetcherActors.cs
@@ -28,9 +28,7 @@ namespace FilmCRUD
         public override IEnumerable<Actor> GetExistingDetailEntitiesInRepo() => this._unitOfWork.Actors.GetAll();
 
         public override async Task<IEnumerable<MovieActorResult>> GetMovieDetailsFromApiAsync(int externalId)
-        {
-            return await this._movieAPIClient.GetMovieActorsAsync(externalId);
-        }
+            => await this._movieAPIClient.GetMovieActorsAsync(externalId);
 
         public override IEnumerable<Movie> GetMoviesWithoutDetails() => this._unitOfWork.Movies.GetMoviesWithoutActors();
 

--- a/FilmCRUD/MovieDetailsFetcherActors.cs
+++ b/FilmCRUD/MovieDetailsFetcherActors.cs
@@ -28,7 +28,7 @@ namespace FilmCRUD
         public override IEnumerable<CastMember> GetExistingDetailEntitiesInRepo() => this._unitOfWork.CastMembers.GetAll();
 
         public override async Task<IEnumerable<MovieCastMemberResult>> GetMovieDetailsFromApiAsync(int externalId)
-            => await this._movieAPIClient.GetMovieActorsAsync(externalId);
+            => await this._movieAPIClient.GetMovieCastMembersAsync(externalId);
 
         public override IEnumerable<Movie> GetMoviesWithoutDetails() => this._unitOfWork.Movies.GetMoviesWithoutCastMembers();
 

--- a/FilmCRUD/MovieDetailsFetcherActors.cs
+++ b/FilmCRUD/MovieDetailsFetcherActors.cs
@@ -40,7 +40,7 @@ namespace FilmCRUD
             // ICollection does not necessarily have the AddRange method
             foreach (var actor in details)
             {
-                movie.Actors.Add(actor);
+                movie.CastMembers.Add(actor);
             }
         }
 

--- a/FilmCRUD/MovieDetailsFetcherActors.cs
+++ b/FilmCRUD/MovieDetailsFetcherActors.cs
@@ -25,7 +25,7 @@ namespace FilmCRUD
             ILogger fetchingErrorsLogger)
             : base(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger) { }
 
-        public override IEnumerable<CastMember> GetExistingDetailEntitiesInRepo() => this._unitOfWork.Actors.GetAll();
+        public override IEnumerable<CastMember> GetExistingDetailEntitiesInRepo() => this._unitOfWork.CastMembers.GetAll();
 
         public override async Task<IEnumerable<MovieActorResult>> GetMovieDetailsFromApiAsync(int externalId)
             => await this._movieAPIClient.GetMovieActorsAsync(externalId);

--- a/FilmCRUD/MovieDetailsFetcherActors.cs
+++ b/FilmCRUD/MovieDetailsFetcherActors.cs
@@ -10,7 +10,7 @@ using MovieAPIClients.Interfaces;
 
 namespace FilmCRUD
 {
-    public class MovieDetailsFetcherActors : MovieDetailsFetcherAbstract<CastMember, MovieActorResult>
+    public class MovieDetailsFetcherActors : MovieDetailsFetcherAbstract<CastMember, MovieCastMemberResult>
     {
         public MovieDetailsFetcherActors(
             IUnitOfWork unitOfWork,
@@ -27,13 +27,13 @@ namespace FilmCRUD
 
         public override IEnumerable<CastMember> GetExistingDetailEntitiesInRepo() => this._unitOfWork.CastMembers.GetAll();
 
-        public override async Task<IEnumerable<MovieActorResult>> GetMovieDetailsFromApiAsync(int externalId)
+        public override async Task<IEnumerable<MovieCastMemberResult>> GetMovieDetailsFromApiAsync(int externalId)
             => await this._movieAPIClient.GetMovieActorsAsync(externalId);
 
         public override IEnumerable<Movie> GetMoviesWithoutDetails() => this._unitOfWork.Movies.GetMoviesWithoutCastMembers();
 
         // explicit cast is defined in MovieCastMemberResult
-        public override CastMember CastApiResultToDetailEntity(MovieActorResult apiresult) => (CastMember)apiresult;
+        public override CastMember CastApiResultToDetailEntity(MovieCastMemberResult apiresult) => (CastMember)apiresult;
 
         public override void AddDetailsToMovieEntity(Movie movie, IEnumerable<CastMember> details)
         {

--- a/FilmCRUD/MovieDetailsFetcherActors.cs
+++ b/FilmCRUD/MovieDetailsFetcherActors.cs
@@ -30,7 +30,7 @@ namespace FilmCRUD
         public override async Task<IEnumerable<MovieActorResult>> GetMovieDetailsFromApiAsync(int externalId)
             => await this._movieAPIClient.GetMovieActorsAsync(externalId);
 
-        public override IEnumerable<Movie> GetMoviesWithoutDetails() => this._unitOfWork.Movies.GetMoviesWithoutActors();
+        public override IEnumerable<Movie> GetMoviesWithoutDetails() => this._unitOfWork.Movies.GetMoviesWithoutCastMembers();
 
         // explicit cast is defined in MovieCastMemberResult
         public override CastMember CastApiResultToDetailEntity(MovieActorResult apiresult) => (CastMember)apiresult;

--- a/FilmCRUD/MovieDetailsFetcherActors.cs
+++ b/FilmCRUD/MovieDetailsFetcherActors.cs
@@ -10,7 +10,7 @@ using MovieAPIClients.Interfaces;
 
 namespace FilmCRUD
 {
-    public class MovieDetailsFetcherActors : MovieDetailsFetcherAbstract<Actor, MovieActorResult>
+    public class MovieDetailsFetcherActors : MovieDetailsFetcherAbstract<CastMember, MovieActorResult>
     {
         public MovieDetailsFetcherActors(
             IUnitOfWork unitOfWork,
@@ -25,7 +25,7 @@ namespace FilmCRUD
             ILogger fetchingErrorsLogger)
             : base(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger) { }
 
-        public override IEnumerable<Actor> GetExistingDetailEntitiesInRepo() => this._unitOfWork.Actors.GetAll();
+        public override IEnumerable<CastMember> GetExistingDetailEntitiesInRepo() => this._unitOfWork.Actors.GetAll();
 
         public override async Task<IEnumerable<MovieActorResult>> GetMovieDetailsFromApiAsync(int externalId)
             => await this._movieAPIClient.GetMovieActorsAsync(externalId);
@@ -33,9 +33,9 @@ namespace FilmCRUD
         public override IEnumerable<Movie> GetMoviesWithoutDetails() => this._unitOfWork.Movies.GetMoviesWithoutActors();
 
         // explicit cast is defined in MovieCastMemberResult
-        public override Actor CastApiResultToDetailEntity(MovieActorResult apiresult) => (Actor)apiresult;
+        public override CastMember CastApiResultToDetailEntity(MovieActorResult apiresult) => (CastMember)apiresult;
 
-        public override void AddDetailsToMovieEntity(Movie movie, IEnumerable<Actor> details)
+        public override void AddDetailsToMovieEntity(Movie movie, IEnumerable<CastMember> details)
         {
             // ICollection does not necessarily have the AddRange method
             foreach (var actor in details)

--- a/FilmCRUD/MovieDetailsFetcherCastMembers.cs
+++ b/FilmCRUD/MovieDetailsFetcherCastMembers.cs
@@ -10,15 +10,15 @@ using MovieAPIClients.Interfaces;
 
 namespace FilmCRUD
 {
-    public class MovieDetailsFetcherActors : MovieDetailsFetcherAbstract<CastMember, MovieCastMemberResult>
+    public class MovieDetailsFetcherCastMembers : MovieDetailsFetcherAbstract<CastMember, MovieCastMemberResult>
     {
-        public MovieDetailsFetcherActors(
+        public MovieDetailsFetcherCastMembers(
             IUnitOfWork unitOfWork,
             IAppSettingsManager appSettingsManager,
             IMovieAPIClient movieAPIClient)
             : base(unitOfWork, appSettingsManager, movieAPIClient) { }
 
-        public MovieDetailsFetcherActors(
+        public MovieDetailsFetcherCastMembers(
             IUnitOfWork unitOfWork,
             IAppSettingsManager appSettingsManager,
             IMovieAPIClient movieAPIClient,

--- a/FilmCRUD/MovieDetailsFetcherCastMembers.cs
+++ b/FilmCRUD/MovieDetailsFetcherCastMembers.cs
@@ -38,9 +38,9 @@ namespace FilmCRUD
         public override void AddDetailsToMovieEntity(Movie movie, IEnumerable<CastMember> details)
         {
             // ICollection does not necessarily have the AddRange method
-            foreach (var actor in details)
+            foreach (var castMember in details)
             {
-                movie.CastMembers.Add(actor);
+                movie.CastMembers.Add(castMember);
             }
         }
 

--- a/FilmCRUD/MovieDetailsFetcherDirectors.cs
+++ b/FilmCRUD/MovieDetailsFetcherDirectors.cs
@@ -28,9 +28,7 @@ namespace FilmCRUD
         public override IEnumerable<Director> GetExistingDetailEntitiesInRepo() => this._unitOfWork.Directors.GetAll();
 
         public override async Task<IEnumerable<MovieDirectorResult>> GetMovieDetailsFromApiAsync(int externalId)
-        {
-            return await this._movieAPIClient.GetMovieDirectorsAsync(externalId);
-        }
+            => await this._movieAPIClient.GetMovieDirectorsAsync(externalId);
 
         public override IEnumerable<Movie> GetMoviesWithoutDetails() => this._unitOfWork.Movies.GetMoviesWithoutDirectors();
 

--- a/FilmCRUD/MovieDetailsFetcherGenres.cs
+++ b/FilmCRUD/MovieDetailsFetcherGenres.cs
@@ -28,9 +28,7 @@ namespace FilmCRUD
         public override IEnumerable<Genre> GetExistingDetailEntitiesInRepo() => this._unitOfWork.Genres.GetAll();
 
         public override async Task<IEnumerable<MovieGenreResult>> GetMovieDetailsFromApiAsync(int externalId)
-        {
-            return await this._movieAPIClient.GetMovieGenresAsync(externalId);
-        }
+            => await this._movieAPIClient.GetMovieGenresAsync(externalId);
 
         public override IEnumerable<Movie> GetMoviesWithoutDetails() => this._unitOfWork.Movies.GetMoviesWithoutGenres();
 

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -481,7 +481,7 @@ namespace FilmCRUD
             else if (opts.CastMembers)
             {
                 ILogger fetchingErrorsLogger = GetLoggerForFetchingErrors("logs/fetching_errors_actors_.txt");
-                var actorsFetcher = new MovieDetailsFetcherActors(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
+                var actorsFetcher = new MovieDetailsFetcherCastMembers(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
                 Log.Information("Fetching actors for movies...");
                 await actorsFetcher.PopulateDetails(opts.MaxCalls ?? -1);
             }

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -295,10 +295,10 @@ namespace FilmCRUD
                 Console.WriteLine($"Movies with genres: {genreNames} \n");
                 moviesWithGenres.ToList().ForEach(m => Console.WriteLine("-------------" + '\n' + m.PrettyFormat()));
             }
-            else if (opts.WithActors.Any())
+            else if (opts.WithCast.Any())
             {
                 // finds the CastMember entities for each string in opts.CastMembers, then flattens
-                IEnumerable<CastMember> actors = opts.WithActors
+                IEnumerable<CastMember> actors = opts.WithCast
                     .Select(name => scanMoviesManager.GetActorsFromName(name))
                     .SelectMany(a => a);
                 IEnumerable<Movie> moviesWithActors = scanMoviesManager.GetMoviesWithActors(visit, actors.ToArray());

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -298,7 +298,7 @@ namespace FilmCRUD
             else if (opts.WithActors.Any())
             {
                 // finds the CastMember entities for each string in opts.CastMembers, then flattens
-                IEnumerable<Actor> actors = opts.WithActors
+                IEnumerable<CastMember> actors = opts.WithActors
                     .Select(name => scanMoviesManager.GetActorsFromName(name))
                     .SelectMany(a => a);
                 IEnumerable<Movie> moviesWithActors = scanMoviesManager.GetMoviesWithActors(visit, actors.ToArray());
@@ -338,7 +338,7 @@ namespace FilmCRUD
             else if (opts.ByActor)
             {
                 Console.WriteLine("Count by actor:\n");
-                IEnumerable<KeyValuePair<Actor, int>> actorCount = scanMoviesManager.GetCountByActor(visit, out int withoutActors);
+                IEnumerable<KeyValuePair<CastMember, int>> actorCount = scanMoviesManager.GetCountByActor(visit, out int withoutActors);
                 int toTake = opts.Top ?? actorCount.Count();
                 actorCount.OrderByDescending(kvp => kvp.Value).ThenBy(kvp => kvp.Key.Name)
                     .Take(toTake)

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -301,7 +301,7 @@ namespace FilmCRUD
                 IEnumerable<CastMember> actors = opts.WithCast
                     .Select(name => scanMoviesManager.GetActorsFromName(name))
                     .SelectMany(a => a);
-                IEnumerable<Movie> moviesWithActors = scanMoviesManager.GetMoviesWithActors(visit, actors.ToArray());
+                IEnumerable<Movie> moviesWithActors = scanMoviesManager.GetMoviesWithCastMembers(visit, actors.ToArray());
                 string actorNames = string.Join(" | ", actors.Select(a => a.Name));
                 Console.WriteLine($"Movies with actors: {actorNames} \n");
                 moviesWithActors.ToList().ForEach(m => Console.WriteLine("-------------" + '\n' + m.PrettyFormat()));

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -299,7 +299,7 @@ namespace FilmCRUD
             {
                 // finds the CastMember entities for each string in opts.CastMembers, then flattens
                 IEnumerable<CastMember> actors = opts.WithCast
-                    .Select(name => scanMoviesManager.GetActorsFromName(name))
+                    .Select(name => scanMoviesManager.GetCastMembersFromName(name))
                     .SelectMany(a => a);
                 IEnumerable<Movie> moviesWithActors = scanMoviesManager.GetMoviesWithCastMembers(visit, actors.ToArray());
                 string actorNames = string.Join(" | ", actors.Select(a => a.Name));

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -302,8 +302,8 @@ namespace FilmCRUD
                     .Select(name => scanMoviesManager.GetCastMembersFromName(name))
                     .SelectMany(a => a);
                 IEnumerable<Movie> moviesWithCastMembers = scanMoviesManager.GetMoviesWithCastMembers(visit, castMembers.ToArray());
-                string actorNames = string.Join(" | ", castMembers.Select(a => a.Name));
-                Console.WriteLine($"Movies with cast: {actorNames} \n");
+                string castMemberNames = string.Join(" | ", castMembers.Select(a => a.Name));
+                Console.WriteLine($"Movies with cast: {castMemberNames} \n");
                 moviesWithCastMembers.ToList().ForEach(m => Console.WriteLine("-------------" + '\n' + m.PrettyFormat()));
             }
             else if (opts.WithDirectors.Any())
@@ -480,10 +480,10 @@ namespace FilmCRUD
             }
             else if (opts.CastMembers)
             {
-                ILogger fetchingErrorsLogger = GetLoggerForFetchingErrors("logs/fetching_errors_actors_.txt");
-                var actorsFetcher = new MovieDetailsFetcherCastMembers(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
-                Log.Information("Fetching actors for movies...");
-                await actorsFetcher.PopulateDetails(opts.MaxCalls ?? -1);
+                ILogger fetchingErrorsLogger = GetLoggerForFetchingErrors("logs/fetching_errors_castmembers_.txt");
+                var castMembersFetcher = new MovieDetailsFetcherCastMembers(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger);
+                Log.Information("Fetching cast members for movies...");
+                await castMembersFetcher.PopulateDetails(opts.MaxCalls ?? -1);
             }
             else if (opts.Directors)
             {

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -297,7 +297,7 @@ namespace FilmCRUD
             }
             else if (opts.WithActors.Any())
             {
-                // finds the Actor entities for each string in opts.WithActors, then flattens
+                // finds the CastMember entities for each string in opts.CastMembers, then flattens
                 IEnumerable<Actor> actors = opts.WithActors
                     .Select(name => scanMoviesManager.GetActorsFromName(name))
                     .SelectMany(a => a);

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -298,13 +298,13 @@ namespace FilmCRUD
             else if (opts.WithCast.Any())
             {
                 // finds the CastMember entities for each string in opts.CastMembers, then flattens
-                IEnumerable<CastMember> actors = opts.WithCast
+                IEnumerable<CastMember> castMembers = opts.WithCast
                     .Select(name => scanMoviesManager.GetCastMembersFromName(name))
                     .SelectMany(a => a);
-                IEnumerable<Movie> moviesWithActors = scanMoviesManager.GetMoviesWithCastMembers(visit, actors.ToArray());
-                string actorNames = string.Join(" | ", actors.Select(a => a.Name));
-                Console.WriteLine($"Movies with actors: {actorNames} \n");
-                moviesWithActors.ToList().ForEach(m => Console.WriteLine("-------------" + '\n' + m.PrettyFormat()));
+                IEnumerable<Movie> moviesWithCastMembers = scanMoviesManager.GetMoviesWithCastMembers(visit, castMembers.ToArray());
+                string actorNames = string.Join(" | ", castMembers.Select(a => a.Name));
+                Console.WriteLine($"Movies with cast: {actorNames} \n");
+                moviesWithCastMembers.ToList().ForEach(m => Console.WriteLine("-------------" + '\n' + m.PrettyFormat()));
             }
             else if (opts.WithDirectors.Any())
             {
@@ -337,14 +337,14 @@ namespace FilmCRUD
             }
             else if (opts.ByCastMember)
             {
-                Console.WriteLine("Count by actor:\n");
-                IEnumerable<KeyValuePair<CastMember, int>> actorCount = scanMoviesManager.GetCountByCastMember(visit, out int withoutActors);
-                int toTake = opts.Top ?? actorCount.Count();
-                actorCount.OrderByDescending(kvp => kvp.Value).ThenBy(kvp => kvp.Key.Name)
+                Console.WriteLine("Count by cast member:\n");
+                IEnumerable<KeyValuePair<CastMember, int>> castMemberCount = scanMoviesManager.GetCountByCastMember(visit, out int withoutCastMembers);
+                int toTake = opts.Top ?? castMemberCount.Count();
+                castMemberCount.OrderByDescending(kvp => kvp.Value).ThenBy(kvp => kvp.Key.Name)
                     .Take(toTake)
                     .ToList()
                     .ForEach(kvp => Console.WriteLine($"{kvp.Key.Name}: {kvp.Value}"));
-                Console.WriteLine($"<empty>: {withoutActors}");
+                Console.WriteLine($"<empty>: {withoutCastMembers}");
             }
             else if (opts.ByDirector)
             {

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -335,7 +335,7 @@ namespace FilmCRUD
                     .ForEach(kvp => Console.WriteLine($"{kvp.Key.Name}: {kvp.Value}"));
                 Console.WriteLine($"<empty>: {withoutGenres}");
             }
-            else if (opts.ByActor)
+            else if (opts.ByCastMember)
             {
                 Console.WriteLine("Count by actor:\n");
                 IEnumerable<KeyValuePair<CastMember, int>> actorCount = scanMoviesManager.GetCountByActor(visit, out int withoutActors);

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -338,7 +338,7 @@ namespace FilmCRUD
             else if (opts.ByCastMember)
             {
                 Console.WriteLine("Count by actor:\n");
-                IEnumerable<KeyValuePair<CastMember, int>> actorCount = scanMoviesManager.GetCountByActor(visit, out int withoutActors);
+                IEnumerable<KeyValuePair<CastMember, int>> actorCount = scanMoviesManager.GetCountByCastMember(visit, out int withoutActors);
                 int toTake = opts.Top ?? actorCount.Count();
                 actorCount.OrderByDescending(kvp => kvp.Value).ThenBy(kvp => kvp.Key.Name)
                     .Take(toTake)

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -478,7 +478,7 @@ namespace FilmCRUD
                 Log.Information("Fetching genres for movies...");
                 await genresFetcher.PopulateDetails(opts.MaxCalls ?? -1);
             }
-            else if (opts.Actors)
+            else if (opts.CastMembers)
             {
                 ILogger fetchingErrorsLogger = GetLoggerForFetchingErrors("logs/fetching_errors_actors_.txt");
                 var actorsFetcher = new MovieDetailsFetcherActors(unitOfWork, appSettingsManager, movieAPIClient, fetchingErrorsLogger);

--- a/FilmCRUD/ScanMoviesManager.cs
+++ b/FilmCRUD/ScanMoviesManager.cs
@@ -29,12 +29,12 @@ namespace FilmCRUD
 
         /// <summary>
         /// Returns all the <see cref="Movie"/> entities linked to some movie rip in <paramref name="visit"/> that have at least
-        /// one actor in param <paramref name="actors"/>.
+        /// one cast member in param <paramref name="castMembers"/>.
         /// </summary>
-        public IEnumerable<Movie> GetMoviesWithActors(MovieWarehouseVisit visit, params CastMember[] actors)
+        public IEnumerable<Movie> GetMoviesWithCastMembers(MovieWarehouseVisit visit, params CastMember[] castMembers)
         {
             IEnumerable<Movie> moviesInVisit = this.UnitOfWork.Movies.GetAllMoviesInVisit(visit);
-            return moviesInVisit.Where(m => actors.Intersect(m.CastMembers).Any());
+            return moviesInVisit.Where(m => castMembers.Intersect(m.CastMembers).Any());
         }
 
         /// <summary>

--- a/FilmCRUD/ScanMoviesManager.cs
+++ b/FilmCRUD/ScanMoviesManager.cs
@@ -116,7 +116,7 @@ namespace FilmCRUD
         /// <summary>
         /// Returns all <see cref="CastMember"/> entities in the repository that fuzzy match parameter <paramref name="name"/>.
         /// </summary>
-        public IEnumerable<CastMember> GetActorsFromName(string name) => this.UnitOfWork.CastMembers.GetCastMembersFromName(name);
+        public IEnumerable<CastMember> GetCastMembersFromName(string name) => this.UnitOfWork.CastMembers.GetCastMembersFromName(name);
 
         /// <summary>
         /// Returns all <see cref="Director"/> entities in the repository that fuzzy match parameter <paramref name="name"/>.

--- a/FilmCRUD/ScanMoviesManager.cs
+++ b/FilmCRUD/ScanMoviesManager.cs
@@ -116,7 +116,7 @@ namespace FilmCRUD
         /// <summary>
         /// Returns all <see cref="CastMember"/> entities in the repository that fuzzy match parameter <paramref name="name"/>.
         /// </summary>
-        public IEnumerable<CastMember> GetActorsFromName(string name) => this.UnitOfWork.Actors.GetActorsFromName(name);
+        public IEnumerable<CastMember> GetActorsFromName(string name) => this.UnitOfWork.Actors.GetCastMembersFromName(name);
 
         /// <summary>
         /// Returns all <see cref="Director"/> entities in the repository that fuzzy match parameter <paramref name="name"/>.

--- a/FilmCRUD/ScanMoviesManager.cs
+++ b/FilmCRUD/ScanMoviesManager.cs
@@ -31,7 +31,7 @@ namespace FilmCRUD
         /// Returns all the <see cref="Movie"/> entities linked to some movie rip in <paramref name="visit"/> that have at least
         /// one actor in param <paramref name="actors"/>.
         /// </summary>
-        public IEnumerable<Movie> GetMoviesWithActors(MovieWarehouseVisit visit, params Actor[] actors)
+        public IEnumerable<Movie> GetMoviesWithActors(MovieWarehouseVisit visit, params CastMember[] actors)
         {
             IEnumerable<Movie> moviesInVisit = this.UnitOfWork.Movies.GetAllMoviesInVisit(visit);
             return moviesInVisit.Where(m => actors.Intersect(m.Actors).Any());
@@ -74,15 +74,15 @@ namespace FilmCRUD
         /// <summary>
         /// Group by and count by actor in all the <see cref="Movie"/> entities linked to some movie rip in <paramref name="visit"/>.
         /// </summary>
-        public IEnumerable<KeyValuePair<Actor, int>> GetCountByActor(MovieWarehouseVisit visit, out int withoutActors)
+        public IEnumerable<KeyValuePair<CastMember, int>> GetCountByActor(MovieWarehouseVisit visit, out int withoutActors)
         {
             IEnumerable<Movie> moviesInVisit = this.UnitOfWork.Movies.GetAllMoviesInVisit(visit);
 
             withoutActors = moviesInVisit.Where(m => !m.Actors.Any()).Count();
 
             // flatten -> group by Actor and count
-            IEnumerable<IGrouping<Actor, Actor>> grouped = moviesInVisit.SelectMany(m => m.Actors).GroupBy(a => a);
-            return grouped.Select(group => new KeyValuePair<Actor, int>(group.Key, group.Count()));
+            IEnumerable<IGrouping<CastMember, CastMember>> grouped = moviesInVisit.SelectMany(m => m.Actors).GroupBy(a => a);
+            return grouped.Select(group => new KeyValuePair<CastMember, int>(group.Key, group.Count()));
         }
 
         /// <summary>
@@ -114,9 +114,9 @@ namespace FilmCRUD
         public IEnumerable<Genre> GenresFromName(string name) => this.UnitOfWork.Genres.GetGenresFromName(name);
 
         /// <summary>
-        /// Returns all <see cref="Actor"/> entities in the repository that fuzzy match parameter <paramref name="name"/>.
+        /// Returns all <see cref="CastMember"/> entities in the repository that fuzzy match parameter <paramref name="name"/>.
         /// </summary>
-        public IEnumerable<Actor> GetActorsFromName(string name) => this.UnitOfWork.Actors.GetActorsFromName(name);
+        public IEnumerable<CastMember> GetActorsFromName(string name) => this.UnitOfWork.Actors.GetActorsFromName(name);
 
         /// <summary>
         /// Returns all <see cref="Director"/> entities in the repository that fuzzy match parameter <paramref name="name"/>.

--- a/FilmCRUD/ScanMoviesManager.cs
+++ b/FilmCRUD/ScanMoviesManager.cs
@@ -72,15 +72,15 @@ namespace FilmCRUD
         }
 
         /// <summary>
-        /// Group by and count by actor in all the <see cref="Movie"/> entities linked to some movie rip in <paramref name="visit"/>.
+        /// Group by and count by cast member in all the <see cref="Movie"/> entities linked to some movie rip in <paramref name="visit"/>.
         /// </summary>
-        public IEnumerable<KeyValuePair<CastMember, int>> GetCountByActor(MovieWarehouseVisit visit, out int withoutActors)
+        public IEnumerable<KeyValuePair<CastMember, int>> GetCountByCastMember(MovieWarehouseVisit visit, out int withoutCastMembers)
         {
             IEnumerable<Movie> moviesInVisit = this.UnitOfWork.Movies.GetAllMoviesInVisit(visit);
 
-            withoutActors = moviesInVisit.Where(m => !m.CastMembers.Any()).Count();
+            withoutCastMembers = moviesInVisit.Where(m => !m.CastMembers.Any()).Count();
 
-            // flatten -> group by Actor and count
+            // flatten -> group by CastMember and count
             IEnumerable<IGrouping<CastMember, CastMember>> grouped = moviesInVisit.SelectMany(m => m.CastMembers).GroupBy(a => a);
             return grouped.Select(group => new KeyValuePair<CastMember, int>(group.Key, group.Count()));
         }

--- a/FilmCRUD/ScanMoviesManager.cs
+++ b/FilmCRUD/ScanMoviesManager.cs
@@ -34,7 +34,7 @@ namespace FilmCRUD
         public IEnumerable<Movie> GetMoviesWithActors(MovieWarehouseVisit visit, params CastMember[] actors)
         {
             IEnumerable<Movie> moviesInVisit = this.UnitOfWork.Movies.GetAllMoviesInVisit(visit);
-            return moviesInVisit.Where(m => actors.Intersect(m.Actors).Any());
+            return moviesInVisit.Where(m => actors.Intersect(m.CastMembers).Any());
         }
 
         /// <summary>
@@ -78,10 +78,10 @@ namespace FilmCRUD
         {
             IEnumerable<Movie> moviesInVisit = this.UnitOfWork.Movies.GetAllMoviesInVisit(visit);
 
-            withoutActors = moviesInVisit.Where(m => !m.Actors.Any()).Count();
+            withoutActors = moviesInVisit.Where(m => !m.CastMembers.Any()).Count();
 
             // flatten -> group by Actor and count
-            IEnumerable<IGrouping<CastMember, CastMember>> grouped = moviesInVisit.SelectMany(m => m.Actors).GroupBy(a => a);
+            IEnumerable<IGrouping<CastMember, CastMember>> grouped = moviesInVisit.SelectMany(m => m.CastMembers).GroupBy(a => a);
             return grouped.Select(group => new KeyValuePair<CastMember, int>(group.Key, group.Count()));
         }
 

--- a/FilmCRUD/ScanMoviesManager.cs
+++ b/FilmCRUD/ScanMoviesManager.cs
@@ -116,7 +116,7 @@ namespace FilmCRUD
         /// <summary>
         /// Returns all <see cref="CastMember"/> entities in the repository that fuzzy match parameter <paramref name="name"/>.
         /// </summary>
-        public IEnumerable<CastMember> GetActorsFromName(string name) => this.UnitOfWork.Actors.GetCastMembersFromName(name);
+        public IEnumerable<CastMember> GetActorsFromName(string name) => this.UnitOfWork.CastMembers.GetCastMembersFromName(name);
 
         /// <summary>
         /// Returns all <see cref="Director"/> entities in the repository that fuzzy match parameter <paramref name="name"/>.

--- a/FilmCRUD/Verbs/FetchOptions.cs
+++ b/FilmCRUD/Verbs/FetchOptions.cs
@@ -8,8 +8,8 @@ namespace FilmCRUD.Verbs
         [Option(SetName = "FetchGenres", HelpText = "fetch genres for movies")]
         public bool Genres { get; set; }
 
-        [Option(SetName = "FetchActors", HelpText = "fetch actors for movies")]
-        public bool Actors { get; set; }
+        [Option(SetName = "FetchCastMembers", HelpText = "fetch cast members for movies")]
+        public bool CastMembers { get; set; }
 
         [Option(SetName = "FetchDirectors", HelpText = "fetch directors for movies")]
         public bool Directors { get; set; }

--- a/FilmCRUD/Verbs/ScanMoviesOptions.cs
+++ b/FilmCRUD/Verbs/ScanMoviesOptions.cs
@@ -21,8 +21,8 @@ namespace FilmCRUD.Verbs
         [Option(SetName = "ByGenreOptions", HelpText = "get descending movie count by genre")]
         public bool ByGenre { get; set; }
 
-        [Option(SetName = "ByActorOptions", HelpText = "get descending movie count by actor")]
-        public bool ByActor { get; set; }
+        [Option(SetName = "ByCastMemberOptions", HelpText = "get descending movie count by cast member")]
+        public bool ByCastMember { get; set; }
 
         [Option(SetName = "SearchOptions", HelpText = "search movies by title")]
         public string Search { get; set; }

--- a/FilmCRUD/Verbs/ScanMoviesOptions.cs
+++ b/FilmCRUD/Verbs/ScanMoviesOptions.cs
@@ -44,8 +44,8 @@ namespace FilmCRUD.Verbs
         [Option('v', "visit", HelpText = "warehouse visit date (YYYYMMDD) to use as the scan target; defaults to the most recent visit")]
         public string Visit { get; set; }
 
-        // can be used with any set, only relevant for GetCountByGenre/Actor/Director
-        [Option('t', "top", HelpText = "integer to limit output count of bygenre/byactor/bydirector and get only the top N")]
+        // can be used with any set, only relevant for GetCountByGenre/CastMember/Director
+        [Option('t', "top", HelpText = "integer to limit output count of bygenre/bycastmember/bydirector and get only the top N")]
         public int? Top { get; set; }
 
 

--- a/FilmCRUD/Verbs/ScanMoviesOptions.cs
+++ b/FilmCRUD/Verbs/ScanMoviesOptions.cs
@@ -9,8 +9,8 @@ namespace FilmCRUD.Verbs
         [Option(SetName = "WithGenreOptions", HelpText = "list movies with genres")]
         public IEnumerable<string> WithGenres { get; set; }
 
-        [Option(SetName = "WithActorOptions", HelpText = "list movies with actors")]
-        public IEnumerable<string> WithActors { get; set; }
+        [Option(SetName = "WithCastOptions", HelpText = "list movies with cast members")]
+        public IEnumerable<string> WithCast { get; set; }
 
         [Option(SetName = "WithDirectorOptions", HelpText = "list movies with directors")]
         public IEnumerable<string> WithDirectors { get; set; }

--- a/FilmDataAccess.EFCore/Migrations/20230103184204_RenamedActorToCastMember.Designer.cs
+++ b/FilmDataAccess.EFCore/Migrations/20230103184204_RenamedActorToCastMember.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FilmDataAccess.EFCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FilmDataAccess.EFCore.Migrations
 {
     [DbContext(typeof(SQLiteAppContext))]
-    partial class SQLiteAppContextModelSnapshot : ModelSnapshot
+    [Migration("20230103184204_RenamedActorToCastMember")]
+    partial class RenamedActorToCastMember
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.7");

--- a/FilmDataAccess.EFCore/Migrations/20230103184204_RenamedActorToCastMember.cs
+++ b/FilmDataAccess.EFCore/Migrations/20230103184204_RenamedActorToCastMember.cs
@@ -1,0 +1,115 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FilmDataAccess.EFCore.Migrations
+{
+    public partial class RenamedActorToCastMember : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ActorMovie");
+
+            migrationBuilder.DropTable(
+                name: "Actors");
+
+            migrationBuilder.CreateTable(
+                name: "CastMembers",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    ExternalId = table.Column<int>(type: "INTEGER", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CastMembers", x => x.Id);
+                    table.UniqueConstraint("AK_CastMembers_ExternalId", x => x.ExternalId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CastMemberMovie",
+                columns: table => new
+                {
+                    CastMembersId = table.Column<int>(type: "INTEGER", nullable: false),
+                    MoviesId = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CastMemberMovie", x => new { x.CastMembersId, x.MoviesId });
+                    table.ForeignKey(
+                        name: "FK_CastMemberMovie_CastMembers_CastMembersId",
+                        column: x => x.CastMembersId,
+                        principalTable: "CastMembers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CastMemberMovie_Movies_MoviesId",
+                        column: x => x.MoviesId,
+                        principalTable: "Movies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CastMemberMovie_MoviesId",
+                table: "CastMemberMovie",
+                column: "MoviesId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CastMemberMovie");
+
+            migrationBuilder.DropTable(
+                name: "CastMembers");
+
+            migrationBuilder.CreateTable(
+                name: "Actors",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    ExternalId = table.Column<int>(type: "INTEGER", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Actors", x => x.Id);
+                    table.UniqueConstraint("AK_Actors_ExternalId", x => x.ExternalId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ActorMovie",
+                columns: table => new
+                {
+                    ActorsId = table.Column<int>(type: "INTEGER", nullable: false),
+                    MoviesId = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ActorMovie", x => new { x.ActorsId, x.MoviesId });
+                    table.ForeignKey(
+                        name: "FK_ActorMovie_Actors_ActorsId",
+                        column: x => x.ActorsId,
+                        principalTable: "Actors",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ActorMovie_Movies_MoviesId",
+                        column: x => x.MoviesId,
+                        principalTable: "Movies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActorMovie_MoviesId",
+                table: "ActorMovie",
+                column: "MoviesId");
+        }
+    }
+}

--- a/FilmDataAccess.EFCore/Migrations/20230103184204_RenamedActorToCastMember.cs
+++ b/FilmDataAccess.EFCore/Migrations/20230103184204_RenamedActorToCastMember.cs
@@ -8,12 +8,6 @@ namespace FilmDataAccess.EFCore.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropTable(
-                name: "ActorMovie");
-
-            migrationBuilder.DropTable(
-                name: "Actors");
-
             migrationBuilder.CreateTable(
                 name: "CastMembers",
                 columns: table => new
@@ -57,16 +51,26 @@ namespace FilmDataAccess.EFCore.Migrations
                 name: "IX_CastMemberMovie_MoviesId",
                 table: "CastMemberMovie",
                 column: "MoviesId");
+
+            // ------------
+            // CUSTOM STEP
+
+            // migrating the previously existing data into thew new tables
+            //   - Actors -> CastMembers (all the known cast members)
+            //   - ActorMovie -> CastMemberMovie (all the known cast members for every movie)
+            migrationBuilder.Sql("insert into CastMembers(Id, Name) select Id, Name from Actors;");
+            migrationBuilder.Sql("insert into CastMemberMovie(CastMembersId, MoviesId) select ActorsId, MoviesId from ActorMovie;");
+
+            // this step was originally in the beginning of the method
+            migrationBuilder.DropTable(
+                name: "ActorMovie");
+
+            migrationBuilder.DropTable(
+                name: "Actors");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropTable(
-                name: "CastMemberMovie");
-
-            migrationBuilder.DropTable(
-                name: "CastMembers");
-
             migrationBuilder.CreateTable(
                 name: "Actors",
                 columns: table => new
@@ -110,6 +114,20 @@ namespace FilmDataAccess.EFCore.Migrations
                 name: "IX_ActorMovie_MoviesId",
                 table: "ActorMovie",
                 column: "MoviesId");
+
+            // ------------
+            // CUSTOM STEP
+
+            // inverse operations of the CUSTOM STEP in the Up method 
+
+            migrationBuilder.Sql("insert into Actors(Id, Name) select Id, Name from CastMembers;");
+            migrationBuilder.Sql("insert into ActorMovie(ActorsId, MoviesId) select CastMembersId, MoviesId from CastMemberMovie;");
+
+            migrationBuilder.DropTable(
+                name: "CastMemberMovie");
+
+            migrationBuilder.DropTable(
+                name: "CastMembers");
         }
     }
 }

--- a/FilmDataAccess.EFCore/Migrations/20230103184204_RenamedActorToCastMember.cs
+++ b/FilmDataAccess.EFCore/Migrations/20230103184204_RenamedActorToCastMember.cs
@@ -58,7 +58,7 @@ namespace FilmDataAccess.EFCore.Migrations
             // migrating the previously existing data into thew new tables
             //   - Actors -> CastMembers (all the known cast members)
             //   - ActorMovie -> CastMemberMovie (all the known cast members for every movie)
-            migrationBuilder.Sql("insert into CastMembers(Id, Name) select Id, Name from Actors;");
+            migrationBuilder.Sql("insert into CastMembers(Id, ExternalId, Name) select Id, ExternalId, Name from Actors;");
             migrationBuilder.Sql("insert into CastMemberMovie(CastMembersId, MoviesId) select ActorsId, MoviesId from ActorMovie;");
 
             // this step was originally in the beginning of the method
@@ -120,7 +120,7 @@ namespace FilmDataAccess.EFCore.Migrations
 
             // inverse operations of the CUSTOM STEP in the Up method 
 
-            migrationBuilder.Sql("insert into Actors(Id, Name) select Id, Name from CastMembers;");
+            migrationBuilder.Sql("insert into Actors(Id, ExternalId, Name) select Id, ExternalId, Name from CastMembers;");
             migrationBuilder.Sql("insert into ActorMovie(ActorsId, MoviesId) select CastMembersId, MoviesId from CastMemberMovie;");
 
             migrationBuilder.DropTable(

--- a/FilmDataAccess.EFCore/ModelConfiguration/ActorEntityTypeConfiguration.cs
+++ b/FilmDataAccess.EFCore/ModelConfiguration/ActorEntityTypeConfiguration.cs
@@ -4,9 +4,9 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace FilmDataAccess.EFCore.ModelConfiguration
 {
-    public class ActorEntityTypeConfiguration : IEntityTypeConfiguration<Actor>
+    public class ActorEntityTypeConfiguration : IEntityTypeConfiguration<CastMember>
     {
-        public void Configure(EntityTypeBuilder<Actor> builder)
+        public void Configure(EntityTypeBuilder<CastMember> builder)
         {
             builder.Property(a => a.Name).IsRequired();
             builder.HasAlternateKey(a => a.ExternalId);

--- a/FilmDataAccess.EFCore/ModelConfiguration/CastMemberEntityTypeConfiguration.cs
+++ b/FilmDataAccess.EFCore/ModelConfiguration/CastMemberEntityTypeConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace FilmDataAccess.EFCore.ModelConfiguration
 {
-    public class ActorEntityTypeConfiguration : IEntityTypeConfiguration<CastMember>
+    public class CastMemberEntityTypeConfiguration : IEntityTypeConfiguration<CastMember>
     {
         public void Configure(EntityTypeBuilder<CastMember> builder)
         {

--- a/FilmDataAccess.EFCore/ModelConfiguration/MovieEntityTypeConfiguration.cs
+++ b/FilmDataAccess.EFCore/ModelConfiguration/MovieEntityTypeConfiguration.cs
@@ -21,7 +21,7 @@ namespace FilmDataAccess.EFCore.ModelConfiguration
                     k => JsonSerializer.Serialize(k, (JsonSerializerOptions)null),
                     k => JsonSerializer.Deserialize<ICollection<string>>(k, (JsonSerializerOptions)null));
 
-            builder.Navigation(m => m.Actors).AutoInclude();
+            builder.Navigation(m => m.CastMembers).AutoInclude();
             builder.Navigation(m => m.Directors).AutoInclude();
             builder.Navigation(m => m.Genres).AutoInclude();
             builder.Navigation(m => m.MovieRips).AutoInclude();

--- a/FilmDataAccess.EFCore/ModelConfiguration/MovieWarehouseVisitEntityTypeConfiguration.cs
+++ b/FilmDataAccess.EFCore/ModelConfiguration/MovieWarehouseVisitEntityTypeConfiguration.cs
@@ -9,8 +9,6 @@ namespace FilmDataAccess.EFCore.ModelConfiguration
         public void Configure(EntityTypeBuilder<MovieWarehouseVisit> builder)
         {
             builder.Property(v => v.VisitDateTime).IsRequired();
-
-            // os objectos MovieWarehouseVisit incluem sempre os MovieRips associados
             builder.Navigation(v => v.MovieRips).AutoInclude();
         }
     }

--- a/FilmDataAccess.EFCore/Repositories/ActorRepository.cs
+++ b/FilmDataAccess.EFCore/Repositories/ActorRepository.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace FilmDataAccess.EFCore.Repositories
 {
-    public class ActorRepository : GenericRepository<CastMember>, IActorRepository
+    public class ActorRepository : GenericRepository<CastMember>, ICastMemberRepository
     {
         public ActorRepository(SQLiteAppContext context) : base(context) { }
 

--- a/FilmDataAccess.EFCore/Repositories/ActorRepository.cs
+++ b/FilmDataAccess.EFCore/Repositories/ActorRepository.cs
@@ -11,19 +11,19 @@ namespace FilmDataAccess.EFCore.Repositories
     {
         public ActorRepository(SQLiteAppContext context) : base(context) { }
 
-        public CastMember FindByExternalId(int externalId) => this._context.Actors.Where(m => m.ExternalId == externalId).FirstOrDefault();
+        public CastMember FindByExternalId(int externalId) => this._context.CastMembers.Where(m => m.ExternalId == externalId).FirstOrDefault();
 
         public IEnumerable<CastMember> GetCastMembersFromName(string name)
         {
             IEnumerable<string> nameTokens = name.GetStringTokensWithoutPunctuation(removeDiacritics: false);
             string nameLike = "%" + string.Join('%', nameTokens) + "%";
 
-            IEnumerable<CastMember> result =  this._context.Actors.Where(a => EF.Functions.Like(a.Name, nameLike));
+            IEnumerable<CastMember> result =  this._context.CastMembers.Where(a => EF.Functions.Like(a.Name, nameLike));
 
             // searches again without diacritics if no results are found
             if (!result.Any())
             {
-                result = _context.Actors.GetEntitiesFromNameFuzzyMatching(name, removeDiacritics: true);
+                result = _context.CastMembers.GetEntitiesFromNameFuzzyMatching(name, removeDiacritics: true);
             }
             return result;
         }

--- a/FilmDataAccess.EFCore/Repositories/ActorRepository.cs
+++ b/FilmDataAccess.EFCore/Repositories/ActorRepository.cs
@@ -13,7 +13,7 @@ namespace FilmDataAccess.EFCore.Repositories
 
         public CastMember FindByExternalId(int externalId) => this._context.Actors.Where(m => m.ExternalId == externalId).FirstOrDefault();
 
-        public IEnumerable<CastMember> GetActorsFromName(string name)
+        public IEnumerable<CastMember> GetCastMembersFromName(string name)
         {
             IEnumerable<string> nameTokens = name.GetStringTokensWithoutPunctuation(removeDiacritics: false);
             string nameLike = "%" + string.Join('%', nameTokens) + "%";

--- a/FilmDataAccess.EFCore/Repositories/ActorRepository.cs
+++ b/FilmDataAccess.EFCore/Repositories/ActorRepository.cs
@@ -7,18 +7,18 @@ using Microsoft.EntityFrameworkCore;
 
 namespace FilmDataAccess.EFCore.Repositories
 {
-    public class ActorRepository : GenericRepository<Actor>, IActorRepository
+    public class ActorRepository : GenericRepository<CastMember>, IActorRepository
     {
         public ActorRepository(SQLiteAppContext context) : base(context) { }
 
-        public Actor FindByExternalId(int externalId) => this._context.Actors.Where(m => m.ExternalId == externalId).FirstOrDefault();
+        public CastMember FindByExternalId(int externalId) => this._context.Actors.Where(m => m.ExternalId == externalId).FirstOrDefault();
 
-        public IEnumerable<Actor> GetActorsFromName(string name)
+        public IEnumerable<CastMember> GetActorsFromName(string name)
         {
             IEnumerable<string> nameTokens = name.GetStringTokensWithoutPunctuation(removeDiacritics: false);
             string nameLike = "%" + string.Join('%', nameTokens) + "%";
 
-            IEnumerable<Actor> result =  this._context.Actors.Where(a => EF.Functions.Like(a.Name, nameLike));
+            IEnumerable<CastMember> result =  this._context.Actors.Where(a => EF.Functions.Like(a.Name, nameLike));
 
             // searches again without diacritics if no results are found
             if (!result.Any())

--- a/FilmDataAccess.EFCore/Repositories/CastMemberRepository.cs
+++ b/FilmDataAccess.EFCore/Repositories/CastMemberRepository.cs
@@ -7,9 +7,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace FilmDataAccess.EFCore.Repositories
 {
-    public class ActorRepository : GenericRepository<CastMember>, ICastMemberRepository
+    public class CastMemberRepository : GenericRepository<CastMember>, ICastMemberRepository
     {
-        public ActorRepository(SQLiteAppContext context) : base(context) { }
+        public CastMemberRepository(SQLiteAppContext context) : base(context) { }
 
         public CastMember FindByExternalId(int externalId) => this._context.CastMembers.Where(m => m.ExternalId == externalId).FirstOrDefault();
 

--- a/FilmDataAccess.EFCore/Repositories/MovieRepository.cs
+++ b/FilmDataAccess.EFCore/Repositories/MovieRepository.cs
@@ -13,7 +13,7 @@ namespace FilmDataAccess.EFCore.Repositories
 
         public Movie FindByExternalId(int externalId) => this._context.Movies.Where(m => m.ExternalId == externalId).FirstOrDefault();
 
-        public IEnumerable<Movie> GetMoviesWithoutActors() => this._context.Movies.Where(m => !m.CastMembers.Any());
+        public IEnumerable<Movie> GetMoviesWithoutCastMembers() => this._context.Movies.Where(m => !m.CastMembers.Any());
 
         public IEnumerable<Movie> GetMoviesWithoutDirectors() => this._context.Movies.Where(m => !m.Directors.Any());
 

--- a/FilmDataAccess.EFCore/Repositories/MovieRepository.cs
+++ b/FilmDataAccess.EFCore/Repositories/MovieRepository.cs
@@ -13,7 +13,7 @@ namespace FilmDataAccess.EFCore.Repositories
 
         public Movie FindByExternalId(int externalId) => this._context.Movies.Where(m => m.ExternalId == externalId).FirstOrDefault();
 
-        public IEnumerable<Movie> GetMoviesWithoutActors() => this._context.Movies.Where(m => !m.Actors.Any());
+        public IEnumerable<Movie> GetMoviesWithoutActors() => this._context.Movies.Where(m => !m.CastMembers.Any());
 
         public IEnumerable<Movie> GetMoviesWithoutDirectors() => this._context.Movies.Where(m => !m.Directors.Any());
 

--- a/FilmDataAccess.EFCore/Repositories/MovieWarehouseVisitRepository.cs
+++ b/FilmDataAccess.EFCore/Repositories/MovieWarehouseVisitRepository.cs
@@ -31,7 +31,8 @@ namespace FilmDataAccess.EFCore.Repositories
 
         private static DateTime GetClosestDatetime(IEnumerable<DateTime> allDateTimes, DateTime dt)
         {
-            if (!allDateTimes.Any()) throw new ArgumentException("Argument is empty", nameof(allDateTimes));
+            if (!allDateTimes.Any())
+                throw new ArgumentException("Argument is empty", nameof(allDateTimes));
             return allDateTimes.OrderBy(_dt => Math.Abs((_dt - dt).Ticks)).First();
         }
     }

--- a/FilmDataAccess.EFCore/SQLiteAppContext.cs
+++ b/FilmDataAccess.EFCore/SQLiteAppContext.cs
@@ -13,7 +13,7 @@ namespace FilmDataAccess.EFCore
 
         public DbSet<Director> Directors { get; set; }
 
-        public DbSet<CastMember> Actors { get; set; }
+        public DbSet<CastMember> CastMembers { get; set; }
 
         public DbSet<MovieRip> MovieRips { get; set; }
 

--- a/FilmDataAccess.EFCore/SQLiteAppContext.cs
+++ b/FilmDataAccess.EFCore/SQLiteAppContext.cs
@@ -33,7 +33,7 @@ namespace FilmDataAccess.EFCore
             modelBuilder.ApplyConfiguration<Genre>(new GenreEntityTypeConfiguration());
             modelBuilder.ApplyConfiguration<MovieRip>(new MovieRipEntityTypeConfiguration());
             modelBuilder.ApplyConfiguration<MovieWarehouseVisit>(new MovieWarehouseVisitEntityTypeConfiguration());
-            modelBuilder.ApplyConfiguration<CastMember>(new ActorEntityTypeConfiguration());
+            modelBuilder.ApplyConfiguration<CastMember>(new CastMemberEntityTypeConfiguration());
         }
 
     }

--- a/FilmDataAccess.EFCore/SQLiteAppContext.cs
+++ b/FilmDataAccess.EFCore/SQLiteAppContext.cs
@@ -13,7 +13,7 @@ namespace FilmDataAccess.EFCore
 
         public DbSet<Director> Directors { get; set; }
 
-        public DbSet<Actor> Actors { get; set; }
+        public DbSet<CastMember> Actors { get; set; }
 
         public DbSet<MovieRip> MovieRips { get; set; }
 
@@ -33,7 +33,7 @@ namespace FilmDataAccess.EFCore
             modelBuilder.ApplyConfiguration<Genre>(new GenreEntityTypeConfiguration());
             modelBuilder.ApplyConfiguration<MovieRip>(new MovieRipEntityTypeConfiguration());
             modelBuilder.ApplyConfiguration<MovieWarehouseVisit>(new MovieWarehouseVisitEntityTypeConfiguration());
-            modelBuilder.ApplyConfiguration<Actor>(new ActorEntityTypeConfiguration());
+            modelBuilder.ApplyConfiguration<CastMember>(new ActorEntityTypeConfiguration());
         }
 
     }

--- a/FilmDataAccess.EFCore/UnitOfWork/SQLiteUnitOfWork.cs
+++ b/FilmDataAccess.EFCore/UnitOfWork/SQLiteUnitOfWork.cs
@@ -30,14 +30,8 @@ namespace FilmDataAccess.EFCore.UnitOfWork
             Actors = new ActorRepository(this._context);
         }
 
-        public int Complete()
-        {
-            return this._context.SaveChanges();
-        }
+        public int Complete() => this._context.SaveChanges();
 
-        public void Dispose()
-        {
-            this._context.Dispose();
-        }
+        public void Dispose() => this._context.Dispose();
     }
 }

--- a/FilmDataAccess.EFCore/UnitOfWork/SQLiteUnitOfWork.cs
+++ b/FilmDataAccess.EFCore/UnitOfWork/SQLiteUnitOfWork.cs
@@ -17,7 +17,7 @@ namespace FilmDataAccess.EFCore.UnitOfWork
 
         public IMovieWarehouseVisitRepository MovieWarehouseVisits { get; init; }
 
-        public ICastMemberRepository Actors { get; init; }
+        public ICastMemberRepository CastMembers { get; init; }
 
         public SQLiteUnitOfWork(SQLiteAppContext context)
         {
@@ -27,7 +27,7 @@ namespace FilmDataAccess.EFCore.UnitOfWork
             this.Genres = new GenreRepository(this._context);
             this.MovieRips = new MovieRipRepository(this._context);
             this.MovieWarehouseVisits = new MovieWarehouseVisitRepository(this._context);
-            this.Actors = new ActorRepository(this._context);
+            this.CastMembers = new ActorRepository(this._context);
         }
 
         public int Complete() => this._context.SaveChanges();

--- a/FilmDataAccess.EFCore/UnitOfWork/SQLiteUnitOfWork.cs
+++ b/FilmDataAccess.EFCore/UnitOfWork/SQLiteUnitOfWork.cs
@@ -22,12 +22,12 @@ namespace FilmDataAccess.EFCore.UnitOfWork
         public SQLiteUnitOfWork(SQLiteAppContext context)
         {
             this._context = context;
-            Movies = new MovieRepository(this._context);
-            Directors = new DirectorRepository(this._context);
-            Genres = new GenreRepository(this._context);
-            MovieRips = new MovieRipRepository(this._context);
-            MovieWarehouseVisits = new MovieWarehouseVisitRepository(this._context);
-            Actors = new ActorRepository(this._context);
+            this.Movies = new MovieRepository(this._context);
+            this.Directors = new DirectorRepository(this._context);
+            this.Genres = new GenreRepository(this._context);
+            this.MovieRips = new MovieRipRepository(this._context);
+            this.MovieWarehouseVisits = new MovieWarehouseVisitRepository(this._context);
+            this.Actors = new ActorRepository(this._context);
         }
 
         public int Complete() => this._context.SaveChanges();

--- a/FilmDataAccess.EFCore/UnitOfWork/SQLiteUnitOfWork.cs
+++ b/FilmDataAccess.EFCore/UnitOfWork/SQLiteUnitOfWork.cs
@@ -21,23 +21,23 @@ namespace FilmDataAccess.EFCore.UnitOfWork
 
         public SQLiteUnitOfWork(SQLiteAppContext context)
         {
-            _context = context;
-            Movies = new MovieRepository(_context);
-            Directors = new DirectorRepository(_context);
-            Genres = new GenreRepository(_context);
-            MovieRips = new MovieRipRepository(_context);
-            MovieWarehouseVisits = new MovieWarehouseVisitRepository(_context);
-            Actors = new ActorRepository(_context);
+            this._context = context;
+            Movies = new MovieRepository(this._context);
+            Directors = new DirectorRepository(this._context);
+            Genres = new GenreRepository(this._context);
+            MovieRips = new MovieRipRepository(this._context);
+            MovieWarehouseVisits = new MovieWarehouseVisitRepository(this._context);
+            Actors = new ActorRepository(this._context);
         }
 
         public int Complete()
         {
-            return _context.SaveChanges();
+            return this._context.SaveChanges();
         }
 
         public void Dispose()
         {
-            _context.Dispose();
+            this._context.Dispose();
         }
     }
 }

--- a/FilmDataAccess.EFCore/UnitOfWork/SQLiteUnitOfWork.cs
+++ b/FilmDataAccess.EFCore/UnitOfWork/SQLiteUnitOfWork.cs
@@ -27,7 +27,7 @@ namespace FilmDataAccess.EFCore.UnitOfWork
             this.Genres = new GenreRepository(this._context);
             this.MovieRips = new MovieRipRepository(this._context);
             this.MovieWarehouseVisits = new MovieWarehouseVisitRepository(this._context);
-            this.CastMembers = new ActorRepository(this._context);
+            this.CastMembers = new CastMemberRepository(this._context);
         }
 
         public int Complete() => this._context.SaveChanges();

--- a/FilmDataAccess.EFCore/UnitOfWork/SQLiteUnitOfWork.cs
+++ b/FilmDataAccess.EFCore/UnitOfWork/SQLiteUnitOfWork.cs
@@ -17,7 +17,7 @@ namespace FilmDataAccess.EFCore.UnitOfWork
 
         public IMovieWarehouseVisitRepository MovieWarehouseVisits { get; init; }
 
-        public IActorRepository Actors { get; init; }
+        public ICastMemberRepository Actors { get; init; }
 
         public SQLiteUnitOfWork(SQLiteAppContext context)
         {

--- a/FilmDomain/Entities/Actor.cs
+++ b/FilmDomain/Entities/Actor.cs
@@ -3,6 +3,7 @@ using FilmDomain.Interfaces;
 
 namespace FilmDomain.Entities
 {
+
     public class Actor : IExternalEntity, INamedEntityWithId
     {
         public int Id { get; set; }

--- a/FilmDomain/Entities/CastMember.cs
+++ b/FilmDomain/Entities/CastMember.cs
@@ -4,7 +4,7 @@ using FilmDomain.Interfaces;
 namespace FilmDomain.Entities
 {
 
-    public class Actor : IExternalEntity, INamedEntityWithId
+    public class CastMember : IExternalEntity, INamedEntityWithId
     {
         public int Id { get; set; }
 

--- a/FilmDomain/Entities/Movie.cs
+++ b/FilmDomain/Entities/Movie.cs
@@ -26,7 +26,7 @@ namespace FilmDomain.Entities
 
         public ICollection<MovieRip> MovieRips { get; set; }
 
-        public ICollection<CastMember> Actors { get; set; }
+        public ICollection<CastMember> CastMembers { get; set; }
 
         public override string ToString()
         {

--- a/FilmDomain/Entities/Movie.cs
+++ b/FilmDomain/Entities/Movie.cs
@@ -26,7 +26,7 @@ namespace FilmDomain.Entities
 
         public ICollection<MovieRip> MovieRips { get; set; }
 
-        public ICollection<Actor> Actors { get; set; }
+        public ICollection<CastMember> Actors { get; set; }
 
         public override string ToString()
         {

--- a/FilmDomain/Extensions/EntityExtensions.cs
+++ b/FilmDomain/Extensions/EntityExtensions.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using FilmDomain.Entities;

--- a/FilmDomain/Interfaces/IActorRepository.cs
+++ b/FilmDomain/Interfaces/IActorRepository.cs
@@ -3,11 +3,11 @@ using FilmDomain.Entities;
 
 namespace FilmDomain.Interfaces
 {
-    public interface IActorRepository : IEntityRepository<Actor>
+    public interface IActorRepository : IEntityRepository<CastMember>
     {
-        IEnumerable<Actor> GetActorsFromName(string name);
+        IEnumerable<CastMember> GetActorsFromName(string name);
 
-        Actor FindByExternalId(int externalId);
+        CastMember FindByExternalId(int externalId);
 
     }
 }

--- a/FilmDomain/Interfaces/ICastMemberRepository.cs
+++ b/FilmDomain/Interfaces/ICastMemberRepository.cs
@@ -3,11 +3,10 @@ using FilmDomain.Entities;
 
 namespace FilmDomain.Interfaces
 {
-    public interface IActorRepository : IEntityRepository<CastMember>
+    public interface ICastMemberRepository : IEntityRepository<CastMember>
     {
         IEnumerable<CastMember> GetActorsFromName(string name);
 
         CastMember FindByExternalId(int externalId);
-
     }
 }

--- a/FilmDomain/Interfaces/ICastMemberRepository.cs
+++ b/FilmDomain/Interfaces/ICastMemberRepository.cs
@@ -5,7 +5,7 @@ namespace FilmDomain.Interfaces
 {
     public interface ICastMemberRepository : IEntityRepository<CastMember>
     {
-        IEnumerable<CastMember> GetActorsFromName(string name);
+        IEnumerable<CastMember> GetCastMembersFromName(string name);
 
         CastMember FindByExternalId(int externalId);
     }

--- a/FilmDomain/Interfaces/IMovieRepository.cs
+++ b/FilmDomain/Interfaces/IMovieRepository.cs
@@ -11,7 +11,7 @@ namespace FilmDomain.Interfaces
 
         IEnumerable<Movie> GetMoviesWithoutGenres();
 
-        IEnumerable<Movie> GetMoviesWithoutActors();
+        IEnumerable<Movie> GetMoviesWithoutCastMembers();
 
         IEnumerable<Movie> GetMoviesWithoutDirectors();
 

--- a/FilmDomain/Interfaces/IUnitOfWork.cs
+++ b/FilmDomain/Interfaces/IUnitOfWork.cs
@@ -14,7 +14,7 @@ namespace FilmDomain.Interfaces
 
         IMovieWarehouseVisitRepository MovieWarehouseVisits { get; }
 
-        IActorRepository Actors { get; }
+        ICastMemberRepository Actors { get; }
 
         int Complete();
     }

--- a/FilmDomain/Interfaces/IUnitOfWork.cs
+++ b/FilmDomain/Interfaces/IUnitOfWork.cs
@@ -14,7 +14,7 @@ namespace FilmDomain.Interfaces
 
         IMovieWarehouseVisitRepository MovieWarehouseVisits { get; }
 
-        ICastMemberRepository Actors { get; }
+        ICastMemberRepository CastMembers { get; }
 
         int Complete();
     }

--- a/MovieAPIClients/Interfaces/IMovieAPIClient.cs
+++ b/MovieAPIClients/Interfaces/IMovieAPIClient.cs
@@ -27,7 +27,7 @@ namespace MovieAPIClients.Interfaces
 
         Task<IEnumerable<MovieGenreResult>> GetMovieGenresAsync(int externalId);
 
-        Task<IEnumerable<MovieCastMemberResult>> GetMovieActorsAsync(int externalId);
+        Task<IEnumerable<MovieCastMemberResult>> GetMovieCastMembersAsync(int externalId);
 
         Task<IEnumerable<MovieDirectorResult>> GetMovieDirectorsAsync(int externalId);
     }

--- a/MovieAPIClients/Interfaces/IMovieAPIClient.cs
+++ b/MovieAPIClients/Interfaces/IMovieAPIClient.cs
@@ -27,7 +27,7 @@ namespace MovieAPIClients.Interfaces
 
         Task<IEnumerable<MovieGenreResult>> GetMovieGenresAsync(int externalId);
 
-        Task<IEnumerable<MovieActorResult>> GetMovieActorsAsync(int externalId);
+        Task<IEnumerable<MovieCastMemberResult>> GetMovieActorsAsync(int externalId);
 
         Task<IEnumerable<MovieDirectorResult>> GetMovieDirectorsAsync(int externalId);
     }

--- a/MovieAPIClients/MovieActorResult.cs
+++ b/MovieAPIClients/MovieActorResult.cs
@@ -9,9 +9,9 @@ namespace MovieAPIClients
 
         public string Name { get; set; }
 
-        public static explicit operator Actor(MovieActorResult movieActorResult)
+        public static explicit operator CastMember(MovieActorResult movieActorResult)
         {
-            return new Actor() {
+            return new CastMember() {
                 ExternalId = movieActorResult.ExternalId,
                 Name = movieActorResult.Name
             };

--- a/MovieAPIClients/MovieCastMemberResult.cs
+++ b/MovieAPIClients/MovieCastMemberResult.cs
@@ -9,11 +9,11 @@ namespace MovieAPIClients
 
         public string Name { get; set; }
 
-        public static explicit operator CastMember(MovieCastMemberResult movieActorResult)
+        public static explicit operator CastMember(MovieCastMemberResult movieCastMemberResult)
         {
             return new CastMember() {
-                ExternalId = movieActorResult.ExternalId,
-                Name = movieActorResult.Name
+                ExternalId = movieCastMemberResult.ExternalId,
+                Name = movieCastMemberResult.Name
             };
         }
     }

--- a/MovieAPIClients/MovieCastMemberResult.cs
+++ b/MovieAPIClients/MovieCastMemberResult.cs
@@ -3,13 +3,13 @@ using FilmDomain.Interfaces;
 
 namespace MovieAPIClients
 {
-    public class MovieActorResult : IExternalEntity
+    public class MovieCastMemberResult : IExternalEntity
     {
         public int ExternalId { get; set; }
 
         public string Name { get; set; }
 
-        public static explicit operator CastMember(MovieActorResult movieActorResult)
+        public static explicit operator CastMember(MovieCastMemberResult movieActorResult)
         {
             return new CastMember() {
                 ExternalId = movieActorResult.ExternalId,

--- a/MovieAPIClients/TheMovieDb/CastResultTMDB.cs
+++ b/MovieAPIClients/TheMovieDb/CastResultTMDB.cs
@@ -13,7 +13,7 @@ namespace MovieAPIClients.TheMovieDb
 
         // for explicit casts:
         //    var objTmdb = new CastResultTMDB();
-        //    var obj = (MovieActorResult)objTmdb;
+        //    var obj = (MovieCastMemberResult)objTmdb;
         public static explicit operator MovieCastMemberResult(CastResultTMDB castResultTMDB)
         {
             return new MovieCastMemberResult() { ExternalId = castResultTMDB.ExternalId, Name = castResultTMDB.Name };

--- a/MovieAPIClients/TheMovieDb/CastResultTMDB.cs
+++ b/MovieAPIClients/TheMovieDb/CastResultTMDB.cs
@@ -14,9 +14,9 @@ namespace MovieAPIClients.TheMovieDb
         // for explicit casts:
         //    var objTmdb = new CastResultTMDB();
         //    var obj = (MovieActorResult)objTmdb;
-        public static explicit operator MovieActorResult(CastResultTMDB castResultTMDB)
+        public static explicit operator MovieCastMemberResult(CastResultTMDB castResultTMDB)
         {
-            return new MovieActorResult() { ExternalId = castResultTMDB.ExternalId, Name = castResultTMDB.Name };
+            return new MovieCastMemberResult() { ExternalId = castResultTMDB.ExternalId, Name = castResultTMDB.Name };
         }
     }
 }

--- a/MovieAPIClients/TheMovieDb/TheMovieDbAPIClient.cs
+++ b/MovieAPIClients/TheMovieDb/TheMovieDbAPIClient.cs
@@ -119,10 +119,10 @@ namespace MovieAPIClients.TheMovieDb
             return resultObj.Genres.Select(g => (MovieGenreResult)g);
         }
 
-        public async Task<IEnumerable<MovieActorResult>> GetMovieActorsAsync(int externalId)
+        public async Task<IEnumerable<MovieCastMemberResult>> GetMovieActorsAsync(int externalId)
         {
             MovieCreditsResultTMDB resultObj = await GetMovieCreditsFromExternalIdAsync(externalId);
-            return resultObj.Cast.Select(c => (MovieActorResult)c);
+            return resultObj.Cast.Select(c => (MovieCastMemberResult)c);
         }
 
         public async Task<IEnumerable<MovieDirectorResult>> GetMovieDirectorsAsync(int externalId)

--- a/MovieAPIClients/TheMovieDb/TheMovieDbAPIClient.cs
+++ b/MovieAPIClients/TheMovieDb/TheMovieDbAPIClient.cs
@@ -119,7 +119,7 @@ namespace MovieAPIClients.TheMovieDb
             return resultObj.Genres.Select(g => (MovieGenreResult)g);
         }
 
-        public async Task<IEnumerable<MovieCastMemberResult>> GetMovieActorsAsync(int externalId)
+        public async Task<IEnumerable<MovieCastMemberResult>> GetMovieCastMembersAsync(int externalId)
         {
             MovieCreditsResultTMDB resultObj = await GetMovieCreditsFromExternalIdAsync(externalId);
             return resultObj.Cast.Select(c => (MovieCastMemberResult)c);


### PR DESCRIPTION
- renaming in **FilmDomain**
  - [x] `Actor `-> `CastMember`
  - [x] member: `Movie.Actors `-> `Movie.CastMembers`
  - [x] `IActorRepository `-> `ICastMemberRepository`
  - [x] member: `IActorRepository.GetActorsFromName `-> `ICastMemberRepository.GetCastMembersFromName`
  - [x] member; `IMovieRepository.GetMoviesWithoutActors `-> `IMovieRepository.GetMoviesWithoutCastMembers`
  - [x] member: `IUnitOfWork.Actors `-> `IUnitOfWork.CastMembers`

- renaming in **MovieAPIClients**
  - [x] member: `IMovieAPIClient.GetMovieActorsAsync `-> `IMovieAPIClient.GetMovieCastMembersAsync`
  - [x] `MovieActorResult `-> `MovieCastMemberResult`
  - [x] param: `public static explicit operator Actor(MovieActorResult movieActorResult) `-> `public static explicit operator CastMember(MovieCastMemberResult movieCastMemberResult)`
  - [x] `TheMovieDbAPIClient.GetMovieActorsAsync `-> `TheMovieDbAPIClient.GetMovieCastMembersAsync`

- renaming in **FilmDataAccess.EFCore**
  - [x] member: `SQLiteAppContext.Actors `-> `SQLiteAppContext.CastMembers`
  - [x] `ActorEntityTypeConfiguration `-> `CastMemberEntityTypeConfiguration`
  - [x] `ActorRepository `-> `CastMemberRepository`
  - [x] member: `ActorRepository.GetActorsFromName `-> `CastMemberRepository.GetCastMembersFromName`
  - [x] member: `MovieRepository.GetMoviesWithoutActors `-> `MovieRepository.GetMoviesWithoutCastMembers`
  - [x] member: `SQLiteUnitOfWork.Actors `-> `SQLiteUnitOfWork.CastMembers`

- renaming in **FilmCRUD**
  - [x] member: `FetchOptions.Actors `-> `FetchOptions.CastMembers`; also, SetName and HelpText
  - [x] member: `ScanMoviesOptions.WithActors `-> `ScanMoviesOptions.WithCast`; also, `SetName `and `HelpText`
  - [x] member: `ScanMoviesOptions.ByActor `-> `ScanMoviesOptions.ByCastMember`; also, `SetName `and `HelpText`
  - [x] `MovieDetailsFetcherActors `-> `MovieDetailsFetcherCastMembers`
  - [x] member: `ScanMoviesManager.GetMoviesWithActors `-> `ScanMoviesManager.GetMoviesWithCastMembers`; also, param name and method docs
  - [x] member: `ScanMoviesManager.GetCountByActor `-> `ScanMoviesManager.GetCountByCastMember`; also, param name and method docs
  - [x] member: `ScanMoviesManager.GetActorsFromName `->  `ScanMoviesManager.GetCastMembersFromName`
  - [x] method `Program.HandleScanMoviesOptions`: console prints, variables
  - [x] method `Program.HandleFetchOptions`: console prints, variables
  - [x] remaining variables and comments in `MovieDetailsFetcherCastMembers`
  - [x] remaining variables and comments in `ScanMoviesOptions`

- renaming in **DepotTests**
  - [x] method `EntityExtensionsTests.GetEntitiesFromNameFuzzyMatching_WithRemoveDiacritics_ShouldReturnCorrectMatches`: variables
  - [x] method `EntityExtensionsTests.GetEntitiesFromNameFuzzyMatching_WithoutRemoveDiacritics_ShouldReturnCorrectMatches`: variables
  - [x] `MovieDetailsFetcherActorsTests `-> `MovieDetailsFetcherCastMembersTests`
  - [x] member: `MovieDetailsFetcherActorsTests._actorRepositoryMock `-> `MovieDetailsFetcherCastMembersTests._castMemberRepositoryMock`
  - [x] member `MovieDetailsFetcherActorsTests._movieDetailsFetcherActors `-> `MovieDetailsFetcherCastMembersTests._movieDetailsFetcherCastMembers`
  - [x] member `MovieDetailsFetcherActorsTests.PopulateDetails_WithoutMoviesMissingActors_ShouldNotCallApiClient `-> `MovieDetailsFetcherCastMembersTests.PopulateDetails_WithoutMoviesMissingCastMembers_ShouldNotCallApiClient `
  - [x] member `MovieDetailsFetcherActorsTests.PopulateDetails_WithMoviesMissingActors_ShouldCallMovieAPIClient `-> `MovieDetailsFetcherCastMembersTests.PopulateDetails_WithMoviesMissingCastMembers_ShouldCallMovieAPIClient`; also variables
  - [x] member `MovieDetailsFetcherActorsTests.PopulateDetails_WithMovieMissingActors_WithExistingActorResultInRepo_ShouldBePopulatedWithExistingActor`-> `MovieDetailsFetcherCastMembersTests.PopulateDetails_WithMovieMissingCastMembers_WithExistingCastMemberResultInRepo_ShouldBePopulatedWithExistingCastMember`; also variables
  - [x] member `MovieDetailsFetcherActorsTests.PopulateDetails_WithMovieMissingActors_WithoutSuchActorsInRepo_ShouldBePopulatedWithNewActorsthExistingActor`-> `MovieDetailsFetcherCastMembersTests.PopulateDetails_WithMovieMissingCastMembers_WithoutSuchCastMembersInRepo_ShouldBePopulatedWithNewCastMembers`; also variables
  - [x] member `MovieDetailsFetcherActorsTests.PopulateDetails_WithMoviesMissingActors_WithoutSuchActorsInRepo_WithSameActorForAllMovies_ShouldBePopulatedWithTheSameActorEntity`-> `MovieDetailsFetcherCastMembersTests.PopulateDetails_WithMoviesMissingCastMembers_WithoutSuchCastMembersInRepo_WithSameCastMemberForAllMovies_ShouldBePopulatedWithTheSameCastMemberEntity`; also variables
  - [x] member: `ScanMoviesManagerTests.GetMoviesWithActors_WithProvidedActors_ShouldReturnCorrectMovies `-> `ScanMoviesManagerTests.GetMoviesWithCastMembers_WithProvidedCastMembers_ShouldReturnCorrectMovies`; also variables
  - [x] member: `ScanMoviesManagerTests.GetCountByActor_ShouldReturnCorrectCount `-> `ScanMoviesManagerTests.GetCountByCastMembers_ShouldReturnCorrectCount`; also variables

- [x] generate migration
- [x] edit migration; example: [_migration.txt](https://github.com/mvcb01/entertainmentdepot/files/10315790/_migration.txt)
- [x] change to main branch and populate db in dev directory: visit --persistcontents, link, fetch
- [x] save FilmDb.db (%userprofile%\Documents\FilmDb_backups\FilmDb_PreMigration.db)
- [x] change back to this branch and apply migration in dev directory
- [x] check CastMember data in db
- [x] test new visit with dummy warehouse contents:
  - [x] visit: list, persist
  - [x] link
  - [x] fetch
  - [x] scan verbs