### PR TITLE
Scan movies verb: include original title in search option and in PrettyFormat

### DIFF
--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -276,7 +276,7 @@ namespace DepotTests.CRUDTests
         [InlineData(" licorice   piZZa")]
         [InlineData(" licorice ! piZZa 2021 -->")]
         [InlineData("??? licorice ==> piZZa (2021)%%$$##")]
-        public void SearchMovieEntitiesByTitle_ShouldReturnCorrectMatches(string title)
+        public void SearchMovieEntities_WithTitleMatch_ShouldReturnCorrectMatches(string title)
         {
             // arrange
             var firstMovie = new Movie() { Title = "uncut gems", ReleaseDate = 2019 };

--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -297,6 +297,37 @@ namespace DepotTests.CRUDTests
             actual.Should().BeEquivalentTo(expected);
         }
 
+        [Theory]
+        [InlineData("O Que Arde")]
+        [InlineData("O Que Arde 2019")]
+        [InlineData("O Que Arde (2019)")]
+        [InlineData("o que arde")]
+        [InlineData("o que arde 2019")]
+        [InlineData("o que arde pizza (2019)")]
+        [InlineData("  o   qUe arDE  ")]
+        [InlineData(" O ! QuE   #( arDe 2019 -->")]
+        [InlineData("!!== o // que aRDE (2019)€€**««»")]
+        public void SearchMovieEntities_WithOriginalTitleMatch_ShouldReturnCorrectMatches(string title)
+        {
+            // arrange
+            var firstMovie = new Movie() { Title = "there will be blood", ReleaseDate = 2007 };
+            var secondMovie = new Movie() { Title = "Licorice Pizza", ReleaseDate = 2021 };
+            var thirdMovie = new Movie() { Title = "Fire Will Come", OriginalTitle = "O que Arde", ReleaseDate = 2019 };
+
+            var visit = new MovieWarehouseVisit() { VisitDateTime = DateTime.ParseExact("20220101", "yyyyMMdd", null) };
+
+            this._movieRepositoryMock
+                .Setup(m => m.GetAllMoviesInVisit(It.Is<MovieWarehouseVisit>(v => v.VisitDateTime == visit.VisitDateTime)))
+                .Returns(new Movie[] { firstMovie, secondMovie, thirdMovie });
+
+            // act
+            IEnumerable<Movie> actual = this._scanMoviesManager.SearchMovieEntities(visit, title);
+
+            // assert
+            var expected = new Movie[] { thirdMovie };
+            actual.Should().BeEquivalentTo(expected);
+        }
+
         [Fact]
         public void GetVisitDiff_WithTwoNullVisits_ShouldThrowArgumentNullException()
         {

--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -303,7 +303,7 @@ namespace DepotTests.CRUDTests
         [InlineData("O Que Arde (2019)")]
         [InlineData("o que arde")]
         [InlineData("o que arde 2019")]
-        [InlineData("o que arde pizza (2019)")]
+        [InlineData("o que arde (2019)")]
         [InlineData("  o   qUe arDE  ")]
         [InlineData(" O ! QuE   #( arDe 2019 -->")]
         [InlineData("!!== o // que aRDE (2019)€€**««»")]

--- a/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanMoviesManagerTests.cs
@@ -290,7 +290,7 @@ namespace DepotTests.CRUDTests
                 .Returns(new Movie[] { firstMovie, secondMovie, thirdMovie });
 
             // act
-            IEnumerable<Movie> actual = this._scanMoviesManager.SearchMovieEntitiesByTitle(visit, title);
+            IEnumerable<Movie> actual = this._scanMoviesManager.SearchMovieEntities(visit, title);
 
             // assert
             var expected = new Movie[] { thirdMovie };

--- a/DepotTests/CRUDTests/ScanRipsManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanRipsManagerTests.cs
@@ -342,5 +342,6 @@ namespace DepotTests.CRUDTests
             actualSearchResult.Should().BeEquivalentTo(
                 visit.MovieRips.Where(mr => idsForExpectedResult.Contains(mr.Id)));
         }
+
     }
 }

--- a/DepotTests/FilmDomainTests/EntityExtensionsTests.cs
+++ b/DepotTests/FilmDomainTests/EntityExtensionsTests.cs
@@ -160,5 +160,71 @@ namespace DepotTests.FilmDomainTests
             // assert
             searchResult.Should().BeEquivalentTo(new[] { firstMovie });
         }
+
+        [Theory]
+        [InlineData("$$#!(!)  A canÇÃo de  !!!$$lisbOA")]
+        [InlineData("a canção    de lisboa ")]
+        [InlineData("a canção de lisboa (1933)")]
+        [InlineData("a cancao de lisboa (1933)")]
+        [InlineData("canção de lisboa 1933")]
+        [InlineData("cancao de lisboa 1933")]
+        public void GetMovieEntitiesFromOriginalTitleFuzzyMatching_WithRemoveDiacritics_ShouldReturnCorrectMatches(string title)
+        {
+            // arrange
+            var firstMovie = new Movie() { OriginalTitle = "The Turin Horse", ReleaseDate = 2011 };
+            var secondMovie = new Movie() { OriginalTitle = "A Canção de Lisboa", ReleaseDate = 1933 };
+            var thirdMovie = new Movie() { OriginalTitle = "Natural Born Killers", ReleaseDate = 1994 };
+
+            var allMovies = new Movie[] { firstMovie, secondMovie, thirdMovie };
+
+            // act
+            IEnumerable<Movie> searchResult = allMovies.GetMovieEntitiesFromOriginalTitleFuzzyMatching(title, removeDiacritics: true);
+
+            // assert
+            searchResult.Should().BeEquivalentTo(new[] { secondMovie });
+        }
+
+        [Theory]
+        [InlineData("$$#!(!)  A canCao de  !!!$$lisbOA")]
+        [InlineData("a cancao de lisboa (1933)")]
+        [InlineData("cancao de lisboa 1933")]
+        public void GetMovieEntitiesFromOriginalTitleFuzzyMatching_WithoutRemoveDiacritics_ShouldReturnCorrectMatches(string title)
+        {
+            // arrange
+            var firstMovie = new Movie() { OriginalTitle = "The Turin Horse", ReleaseDate = 2011 };
+            var secondMovie = new Movie() { OriginalTitle = "A Cancao de Lisboa", ReleaseDate = 1933 };
+            var thirdMovie = new Movie() { OriginalTitle = "Natural Born Killers", ReleaseDate = 1994 };
+            var fourthMovie = new Movie() { OriginalTitle = "A Canção de Lisboa", ReleaseDate = 1933 };
+
+            var allMovies = new Movie[] { firstMovie, secondMovie, thirdMovie, fourthMovie };
+
+            // act
+            IEnumerable<Movie> searchResult = allMovies.GetMovieEntitiesFromOriginalTitleFuzzyMatching(title, removeDiacritics: false);
+
+            // assert
+            searchResult.Should().BeEquivalentTo(new[] { secondMovie });
+        }
+
+        [Theory]
+        [InlineData("dead man's shoes")]
+        [InlineData("dead mans shoes")]
+        [InlineData("dead man's shoes (2004)")]
+        [InlineData("dead mans shoes (2004)")]
+        public void GetMovieEntitiesFromOriginalTitleFuzzyMatching_WithRemoveDiacritics_WithSingleQuotesInMovieTitle_ShouldReturnCorrectMatches(string title)
+        {
+            // arrange
+            var firstMovie = new Movie() { OriginalTitle = "Dead Man's Shoes", ReleaseDate = 2004 };
+            var secondMovie = new Movie() { OriginalTitle = "The Turin Horse", ReleaseDate = 2011 };
+            var thirdMovie = new Movie() { OriginalTitle = "Natural Born Killers", ReleaseDate = 1994 };
+            var fourthMovie = new Movie() { OriginalTitle = "Sátántangó", ReleaseDate = 1994 };
+
+            var allMovies = new Movie[] { firstMovie, secondMovie, thirdMovie, fourthMovie };
+
+            // act
+            IEnumerable<Movie> searchResult = allMovies.GetMovieEntitiesFromOriginalTitleFuzzyMatching(title, removeDiacritics: false);
+
+            // assert
+            searchResult.Should().BeEquivalentTo(new[] { firstMovie });
+        }
     }
 }

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -361,7 +361,7 @@ namespace FilmCRUD
             {
                 string toSearch = opts.Search;
                 Console.WriteLine($"Search by title: \"{toSearch}\" \n");
-                IEnumerable<Movie> searchResult = scanMoviesManager.SearchMovieEntitiesByTitle(visit, toSearch);
+                IEnumerable<Movie> searchResult = scanMoviesManager.SearchMovieEntities(visit, toSearch);
                 if (!searchResult.Any())
                 {
                     Console.WriteLine("No matches...");

--- a/FilmCRUD/ScanMoviesManager.cs
+++ b/FilmCRUD/ScanMoviesManager.cs
@@ -106,7 +106,9 @@ namespace FilmCRUD
         public IEnumerable<Movie> SearchMovieEntities(MovieWarehouseVisit visit, string title)
         {
             IEnumerable<Movie> moviesInVisit = this.UnitOfWork.Movies.GetAllMoviesInVisit(visit);
-            return moviesInVisit.GetMovieEntitiesFromTitleFuzzyMatching(title, removeDiacritics: true);
+            IEnumerable<Movie> fuzzyMatchTitle = moviesInVisit.GetMovieEntitiesFromTitleFuzzyMatching(title, removeDiacritics: true);
+            IEnumerable<Movie> fuzzyMatchOriginalTitle = moviesInVisit.GetMovieEntitiesFromOriginalTitleFuzzyMatching(title, removeDiacritics: true);
+            return fuzzyMatchTitle.Concat(fuzzyMatchOriginalTitle);
         }
 
         /// <summary>

--- a/FilmCRUD/ScanMoviesManager.cs
+++ b/FilmCRUD/ScanMoviesManager.cs
@@ -103,7 +103,7 @@ namespace FilmCRUD
         /// Fuzzy match search on all the <see cref="Movie"/> entities linked to some movie rip in <paramref name="visit"/>. Both
         /// properties <see cref="Movie.Title"/> and <see cref="Movie.OriginalTitle"/> are used in the search.
         /// </summary>
-        public IEnumerable<Movie> SearchMovieEntitiesByTitle(MovieWarehouseVisit visit, string title)
+        public IEnumerable<Movie> SearchMovieEntities(MovieWarehouseVisit visit, string title)
         {
             IEnumerable<Movie> moviesInVisit = this.UnitOfWork.Movies.GetAllMoviesInVisit(visit);
             return moviesInVisit.GetMovieEntitiesFromTitleFuzzyMatching(title, removeDiacritics: true);

--- a/FilmCRUD/ScanMoviesManager.cs
+++ b/FilmCRUD/ScanMoviesManager.cs
@@ -100,7 +100,8 @@ namespace FilmCRUD
         }
 
         /// <summary>
-        /// Title fuzzy match search on all the <see cref="Movie"/> entities linked to some movie rip in <paramref name="visit"/>.
+        /// Fuzzy match search on all the <see cref="Movie"/> entities linked to some movie rip in <paramref name="visit"/>. Both
+        /// properties <see cref="Movie.Title"/> and <see cref="Movie.OriginalTitle"/> are used in the search.
         /// </summary>
         public IEnumerable<Movie> SearchMovieEntitiesByTitle(MovieWarehouseVisit visit, string title)
         {

--- a/FilmDomain/Extensions/EntityExtensions.cs
+++ b/FilmDomain/Extensions/EntityExtensions.cs
@@ -63,7 +63,7 @@ namespace FilmDomain.Extensions
 
         /// <summary>
         /// Searches the provided entities <see cref="Movie"/> and returns the entities such that property <see cref="Movie.Title"/>
-        /// fuzzy matches provided parameter <paramref name="title"/>.
+        /// fuzzy matches the provided parameter <paramref name="title"/>.
         /// </summary>
         /// <param name="allMovies">The entities to search</param>
         /// <param name="title">The title to search</param>
@@ -79,7 +79,7 @@ namespace FilmDomain.Extensions
 
         /// <summary>
         /// Searches the provided entities <see cref="Movie"/> and returns the entities such that property <see cref="Movie.OriginalTitle"/>
-        /// fuzzy matches provided parameter <paramref name="title"/>.
+        /// fuzzy matches the provided parameter <paramref name="title"/>.
         /// </summary>
         /// <param name="allMovies">The entities to search</param>
         /// <param name="title">The original title to search</param>

--- a/FilmDomain/Extensions/EntityExtensions.cs
+++ b/FilmDomain/Extensions/EntityExtensions.cs
@@ -111,7 +111,14 @@ namespace FilmDomain.Extensions
             string _genres = movie.Genres == null ? string.Empty : string.Join(" | ", movie.Genres.Select(g => g.Name));
             string _directors = movie.Directors == null ? string.Empty : string.Join(", ", movie.Directors.Select(d => d.Name));
             string _kwds = movie.Keywords == null ? string.Empty : string.Join(", ", movie.Keywords);
-            return string.Join('\n', new string[] {movie.ToString(), _genres, $"Directors: {_directors}", $"IMDB id: {movie.IMDBId}", $"Keywords: {_kwds}" });
+            string _originalTitle = movie.OriginalTitle ?? "-";
+            return string.Join('\n', new string[] {
+                movie.ToString(),
+                _genres,
+                $"Original title: {_originalTitle}",
+                $"Directors: {_directors}",
+                $"IMDB id: {movie.IMDBId}",
+                $"Keywords: {_kwds}" });
         }
 
         public static string PrettyFormat(this MovieRip movieRip)

--- a/FilmDomain/Extensions/EntityExtensions.cs
+++ b/FilmDomain/Extensions/EntityExtensions.cs
@@ -62,8 +62,8 @@ namespace FilmDomain.Extensions
         }
 
         /// <summary>
-        /// Searches the provided <see cref="Movie"/> entities and returns the ones that have a property <see cref="Movie.Title"/>
-        /// fuzzy matching parameter <paramref name="title"/>.
+        /// Searches the provided entities <see cref="Movie"/> and returns the entities such that property <see cref="Movie.Title"/>
+        /// fuzzy matches provided parameter <paramref name="title"/>.
         /// </summary>
         /// <param name="allMovies">The entities to search</param>
         /// <param name="title">The title to search</param>

--- a/FilmDomain/Extensions/EntityExtensions.cs
+++ b/FilmDomain/Extensions/EntityExtensions.cs
@@ -142,6 +142,16 @@ namespace FilmDomain.Extensions
             bool removeDiacritics,
             Func<Movie, string> propertyGetter)
         {
+            // local func; null safety refers to the movie property getter;
+            // not a static func since it uses the containing method params propertyGetter and removeDiacritics
+            string RemovePunctuationFromMoviePropertyNullSafe(Movie movie, bool removeSingleQuotes)
+            {
+                string movieProperty = propertyGetter(movie) ?? string.Empty;
+                if (removeSingleQuotes)
+                    movieProperty = movieProperty.Replace("\'", string.Empty);
+                return string.Join(' ', movieProperty.GetStringTokensWithoutPunctuation(removeDiacritics: removeDiacritics));
+            }
+
             var titleTokensWithoutPunctuation = title.GetStringTokensWithoutPunctuation(removeDiacritics: removeDiacritics);
 
             if (!titleTokensWithoutPunctuation.Any())
@@ -150,7 +160,7 @@ namespace FilmDomain.Extensions
             string titleRegex = @"(\s*)(" + string.Join(@")(\s*)(", titleTokensWithoutPunctuation) + @")(\s*)";
 
             IEnumerable<Movie> result = allMovies.Where(m => Regex.IsMatch(
-                string.Join(' ', propertyGetter(m).GetStringTokensWithoutPunctuation(removeDiacritics: removeDiacritics)),
+                RemovePunctuationFromMoviePropertyNullSafe(m, removeSingleQuotes: false),
                 titleRegex,
                 RegexOptions.IgnoreCase));
 
@@ -158,7 +168,7 @@ namespace FilmDomain.Extensions
             if (!result.Any())
             {
                 result = allMovies.Where(m => Regex.IsMatch(
-                    string.Join(' ', propertyGetter(m).Replace("\'", string.Empty).GetStringTokensWithoutPunctuation(removeDiacritics: removeDiacritics)),
+                    RemovePunctuationFromMoviePropertyNullSafe(m, removeSingleQuotes: true),
                     titleRegex,
                     RegexOptions.IgnoreCase));
             }
@@ -174,11 +184,11 @@ namespace FilmDomain.Extensions
                 IEnumerable<Movie> extraResults = allMovies.Where(
                     m => m.ReleaseDate == parsedReleaseDate
                         && (Regex.IsMatch(
-                                string.Join(' ', propertyGetter(m).GetStringTokensWithoutPunctuation(removeDiacritics: removeDiacritics)),
+                                RemovePunctuationFromMoviePropertyNullSafe(m, removeSingleQuotes: false),
                                 titleRegexNoDate,
                                 RegexOptions.IgnoreCase)
                             || Regex.IsMatch(
-                                string.Join(' ', propertyGetter(m).Replace("\'", string.Empty).GetStringTokensWithoutPunctuation(removeDiacritics: removeDiacritics)),
+                                RemovePunctuationFromMoviePropertyNullSafe(m, removeSingleQuotes: true),
                                 titleRegexNoDate,
                                 RegexOptions.IgnoreCase)));
                 result = result.Concat(extraResults);

--- a/FilmDomain/Extensions/EntityExtensions.cs
+++ b/FilmDomain/Extensions/EntityExtensions.cs
@@ -78,12 +78,12 @@ namespace FilmDomain.Extensions
         }
 
         /// <summary>
-        /// Searches the provided entities <see cref="Movie"/> and returns the entities such that property <see cref="Movie.Title"/>
+        /// Searches the provided entities <see cref="Movie"/> and returns the entities such that property <see cref="Movie.OriginalTitle"/>
         /// fuzzy matches provided parameter <paramref name="title"/>.
         /// </summary>
         /// <param name="allMovies">The entities to search</param>
-        /// <param name="title">The title to search</param>
-        /// <param name="removeDiacritics">Whether or no to remove diacritics when comparing <paramref name="title"/> and <see cref="Movie.Title"/>.</param>
+        /// <param name="title">The original title to search</param>
+        /// <param name="removeDiacritics">Whether or no to remove diacritics when comparing <paramref name="title"/> and <see cref="Movie.OriginalTitle"/>.</param>
         /// <returns>The search result</returns>
         public static IEnumerable<Movie> GetMovieEntitiesFromOriginalTitleFuzzyMatching(
             this IEnumerable<Movie> allMovies,

--- a/FilmDomain/Extensions/EntityExtensions.cs
+++ b/FilmDomain/Extensions/EntityExtensions.cs
@@ -85,10 +85,7 @@ namespace FilmDomain.Extensions
         public static IEnumerable<Movie> GetMovieEntitiesFromOriginalTitleFuzzyMatching(
             this IEnumerable<Movie> allMovies,
             string title,
-            bool removeDiacritics = false)
-        {
-            throw new NotImplementedException();
-        }
+            bool removeDiacritics = false) => SearchMovieEntitiesByFuzzyMatching(allMovies, title, removeDiacritics, m => m.OriginalTitle);
 
         // taken from
         // https://stackoverflow.com/questions/249087/how-do-i-remove-diacritics-accents-from-a-string-in-net/249126#249126

--- a/FilmDomain/Extensions/EntityExtensions.cs
+++ b/FilmDomain/Extensions/EntityExtensions.cs
@@ -136,6 +136,12 @@ namespace FilmDomain.Extensions
                 _linkedMovie });
         }
 
+        /// <summary>
+        /// Implements the logic behind extensions <see cref="GetMovieEntitiesFromTitleFuzzyMatching"/> and
+        /// <see cref="GetMovieEntitiesFromOriginalTitleFuzzyMatching"/>, while allowing client code to pass parameter
+        /// <paramref name="propertyGetter"/> in order to choose the <see cref="Movie"/> property to use on fuzzy
+        /// matching.
+        /// </summary>
         private static IEnumerable<Movie> SearchMovieEntitiesByFuzzyMatching(
             IEnumerable<Movie> allMovies,
             string title,

--- a/FilmDomain/Extensions/EntityExtensions.cs
+++ b/FilmDomain/Extensions/EntityExtensions.cs
@@ -72,10 +72,7 @@ namespace FilmDomain.Extensions
         public static IEnumerable<Movie> GetMovieEntitiesFromTitleFuzzyMatching(
             this IEnumerable<Movie> allMovies,
             string title,
-            bool removeDiacritics = false)
-        {
-            return SearchMovieEntitiesByFuzzyMatching(allMovies, title, removeDiacritics, m => m.Title);
-        }
+            bool removeDiacritics = false) => SearchMovieEntitiesByFuzzyMatching(allMovies, title, removeDiacritics, m => m.Title);
 
         /// <summary>
         /// Searches the provided entities <see cref="Movie"/> and returns the entities such that property <see cref="Movie.OriginalTitle"/>

--- a/FilmDomain/Extensions/EntityExtensions.cs
+++ b/FilmDomain/Extensions/EntityExtensions.cs
@@ -68,7 +68,7 @@ namespace FilmDomain.Extensions
         /// <param name="allMovies">The entities to search</param>
         /// <param name="title">The title to search</param>
         /// <param name="removeDiacritics">Whether or no to remove diacritics when comparing <paramref name="title"/> and <see cref="Movie.Title"/>.</param>
-        /// <returns></returns>
+        /// <returns>The search result</returns>
         public static IEnumerable<Movie> GetMovieEntitiesFromTitleFuzzyMatching(
             this IEnumerable<Movie> allMovies,
             string title,
@@ -117,6 +117,22 @@ namespace FilmDomain.Extensions
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Searches the provided entities <see cref="Movie"/> and returns the entities such that property <see cref="Movie.Title"/>
+        /// fuzzy matches provided parameter <paramref name="title"/>.
+        /// </summary>
+        /// <param name="allMovies">The entities to search</param>
+        /// <param name="title">The title to search</param>
+        /// <param name="removeDiacritics">Whether or no to remove diacritics when comparing <paramref name="title"/> and <see cref="Movie.Title"/>.</param>
+        /// <returns>The search result</returns>
+        public static IEnumerable<Movie> GetMovieEntitiesFromOriginalTitleFuzzyMatching(
+            this IEnumerable<Movie> allMovies,
+            string title,
+            bool removeDiacritics = false)
+        {
+            throw new NotImplementedException();
         }
 
         // taken from

--- a/FilmDomain/Extensions/EntityExtensions.cs
+++ b/FilmDomain/Extensions/EntityExtensions.cs
@@ -61,6 +61,14 @@ namespace FilmDomain.Extensions
                 RegexOptions.IgnoreCase));
         }
 
+        /// <summary>
+        /// Searches the provided <see cref="Movie"/> entities and returns the ones that have a property <see cref="Movie.Title"/>
+        /// fuzzy matching parameter <paramref name="title"/>.
+        /// </summary>
+        /// <param name="allMovies">The entities to search</param>
+        /// <param name="title">The title to search</param>
+        /// <param name="removeDiacritics">Whether or no to remove diacritics when comparing <paramref name="title"/> and <see cref="Movie.Title"/>.</param>
+        /// <returns></returns>
         public static IEnumerable<Movie> GetMovieEntitiesFromTitleFuzzyMatching(
             this IEnumerable<Movie> allMovies,
             string title,
@@ -152,6 +160,15 @@ namespace FilmDomain.Extensions
                 _id, _filename, _parsedTitle, _parsedReleaseDate,
                 _parsedRipQuality, _parsedRipInfo, _parsedRipGroup,
                 _linkedMovie });
+        }
+
+        private static IEnumerable<Movie> GetMovieEntitiesFromTitleFuzzyMatching(
+            IEnumerable<Movie> allMovies,
+            string title,
+            bool removeDiacritics,
+            Func<Movie, string> propertyGetter)
+        {
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
- amend extension `GetMovieEntitiesFromTitleFuzzyMatching`
  - [x] create new private static method `EntityExtensions.SearchMovieEntitiesByFuzzyMatching` that will receive a delegate that returns the `Movie` property to use when matching: `Title` or `OriginalTitle`
  - [x] call such method from `GetMovieEntitiesFromTitleFuzzyMatching`

- [x] create new extension `GetMovieEntitiesFromOriginalTitleFuzzyMatching` with tests
- [x] rename `ScanMoviesManager.SearchMovieEntitiesByTitle `-> `ScanMoviesManager.SearchMovieEntities`
- [x] call both extension methods in `ScanMoviesManager.SearchMovieEntities` and return all results: `EntityExtensions.GetMovieEntitiesFromFuzzyMatching` and `EntityExtensions.GetMovieEntitiesFromOriginalTitleFuzzyMatching`; also tests;
- [x] extension `PrettyFormat(this Movie movie)`: include original title
- [x] test cli using dev database